### PR TITLE
API-14201 F: V1: Endpoint latency issues

### DIFF
--- a/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/DeserializerUtil.java
+++ b/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/DeserializerUtil.java
@@ -9,7 +9,7 @@ public class DeserializerUtil {
   /** Obtain active status node using snake_case or camelCase notation. */
   public static JsonNode getActiveStatus(@NonNull JsonNode node) {
     JsonNode activeStatusNode = node.get("active_status");
-    if (activeStatusNode == null) {
+    if (isNull(activeStatusNode)) {
       activeStatusNode = node.get("activeStatus");
     }
     return activeStatusNode;
@@ -18,7 +18,7 @@ public class DeserializerUtil {
   /** Obtain additional hours info node using snake_case or camelCase notation. */
   public static JsonNode getAdditionalHoursInfo(@NonNull JsonNode node) {
     JsonNode additionalHoursInfoNode = node.get("additional_hours_info");
-    if (additionalHoursInfoNode == null) {
+    if (isNull(additionalHoursInfoNode)) {
       additionalHoursInfoNode = node.get("additionalHoursInfo");
     }
     return additionalHoursInfoNode;
@@ -27,7 +27,7 @@ public class DeserializerUtil {
   /** Obtain additional info node using snake_case or camelCase notation. */
   public static JsonNode getAdditionalInfo(@NonNull JsonNode node) {
     JsonNode additionalInfoNode = node.get("additional_info");
-    if (additionalInfoNode == null) {
+    if (isNull(additionalInfoNode)) {
       additionalInfoNode = node.get("additionalInfo");
     }
     return additionalInfoNode;
@@ -36,7 +36,7 @@ public class DeserializerUtil {
   /** Obtain address 1 node using snake_case or camelCase notation. */
   public static JsonNode getAddress1(@NonNull JsonNode node) {
     JsonNode address1Node = node.get("address_1");
-    if (address1Node == null) {
+    if (isNull(address1Node)) {
       address1Node = node.get("address1");
     }
     return address1Node;
@@ -45,7 +45,7 @@ public class DeserializerUtil {
   /** Obtain address 2 node using snake_case or camelCase notation. */
   public static JsonNode getAddress2(@NonNull JsonNode node) {
     JsonNode address2Node = node.get("address_2");
-    if (address2Node == null) {
+    if (isNull(address2Node)) {
       address2Node = node.get("address2");
     }
     return address2Node;
@@ -54,7 +54,7 @@ public class DeserializerUtil {
   /** Obtain address 3 node using snake_case or camelCase notation. */
   public static JsonNode getAddress3(@NonNull JsonNode node) {
     JsonNode address3Node = node.get("address_3");
-    if (address3Node == null) {
+    if (isNull(address3Node)) {
       address3Node = node.get("address3");
     }
     return address3Node;
@@ -63,7 +63,7 @@ public class DeserializerUtil {
   /** Obtain address line 1 node using snake_case or camelCase notation. */
   public static JsonNode getAddressLine1(@NonNull JsonNode node) {
     JsonNode addressLine1Node = node.get("address_line1");
-    if (addressLine1Node == null) {
+    if (isNull(addressLine1Node)) {
       addressLine1Node = node.get("addressLine1");
     }
     return addressLine1Node;
@@ -72,7 +72,7 @@ public class DeserializerUtil {
   /** Obtain address line 2 node using snake_case or camelCase notation. */
   public static JsonNode getAddressLine2(@NonNull JsonNode node) {
     JsonNode addressLine2Node = node.get("address_line2");
-    if (addressLine2Node == null) {
+    if (isNull(addressLine2Node)) {
       addressLine2Node = node.get("addressLine2");
     }
     return addressLine2Node;
@@ -81,7 +81,7 @@ public class DeserializerUtil {
   /** Obtain after hours node using snake_case or camelCase notation. */
   public static JsonNode getAfterHours(@NonNull JsonNode node) {
     JsonNode afterHoursNode = node.get("after_hours");
-    if (afterHoursNode == null) {
+    if (isNull(afterHoursNode)) {
       afterHoursNode = node.get("afterHours");
     }
     return afterHoursNode;
@@ -90,10 +90,10 @@ public class DeserializerUtil {
   /** Obtain appointment leadin node using snake_case or camelCase notation. */
   public static JsonNode getAppointmentLeadin(@NonNull JsonNode node) {
     JsonNode appointmentLeadInNode = node.get("appointment_leadin");
-    if (appointmentLeadInNode == null) {
+    if (isNull(appointmentLeadInNode)) {
       appointmentLeadInNode = node.get("appointmentLeadIn");
     }
-    if (appointmentLeadInNode == null) {
+    if (isNull(appointmentLeadInNode)) {
       appointmentLeadInNode = node.get("appointmentLeadin");
     }
     return appointmentLeadInNode;
@@ -102,7 +102,7 @@ public class DeserializerUtil {
   /** Obtain building name number node using snake_case or camelCase notation. */
   public static JsonNode getBuildingNameNumber(@NonNull JsonNode node) {
     JsonNode buildingNameNumberNode = node.get("building_name_number");
-    if (buildingNameNumberNode == null) {
+    if (isNull(buildingNameNumberNode)) {
       buildingNameNumberNode = node.get("buildingNameNumber");
     }
     return buildingNameNumberNode;
@@ -111,7 +111,7 @@ public class DeserializerUtil {
   /** Obtain clinic name node using snake_case or camelCase notation. */
   public static JsonNode getClinicName(@NonNull JsonNode node) {
     JsonNode clinicNameNode = node.get("clinic_name");
-    if (clinicNameNode == null) {
+    if (isNull(clinicNameNode)) {
       clinicNameNode = node.get("clinicName");
     }
     return clinicNameNode;
@@ -120,7 +120,7 @@ public class DeserializerUtil {
   /** Obtain country code node using snake_case or camelCase notation. */
   public static JsonNode getCountryCode(@NonNull JsonNode node) {
     JsonNode countryCodeNode = node.get("country_code");
-    if (countryCodeNode == null) {
+    if (isNull(countryCodeNode)) {
       countryCodeNode = node.get("countryCode");
     }
     return countryCodeNode;
@@ -129,7 +129,7 @@ public class DeserializerUtil {
   /** Obtain detailed services node using snake_case or camelCase notation. */
   public static JsonNode getDetailedServices(@NonNull JsonNode node) {
     JsonNode detailedServicesNode = node.get("detailed_services");
-    if (detailedServicesNode == null) {
+    if (isNull(detailedServicesNode)) {
       detailedServicesNode = node.get("detailedServices");
     }
     return detailedServicesNode;
@@ -138,7 +138,7 @@ public class DeserializerUtil {
   /** Obtain effective date node using snake_case or camelCase notation. */
   public static JsonNode getEffectiveDate(@NonNull JsonNode node) {
     JsonNode effectiveDateNode = node.get("effective_date");
-    if (effectiveDateNode == null) {
+    if (isNull(effectiveDateNode)) {
       effectiveDateNode = node.get("effectiveDate");
     }
     return effectiveDateNode;
@@ -147,7 +147,7 @@ public class DeserializerUtil {
   /** Obtain email address node using snake_case or camelCase notation. */
   public static JsonNode getEmailAddress(@NonNull JsonNode node) {
     JsonNode emailAddressNode = node.get("email_address");
-    if (emailAddressNode == null) {
+    if (isNull(emailAddressNode)) {
       emailAddressNode = node.get("emailAddress");
     }
     return emailAddressNode;
@@ -156,7 +156,7 @@ public class DeserializerUtil {
   /** Obtain email contacts node using snake_case or camelCase notation. */
   public static JsonNode getEmailContacts(@NonNull JsonNode node) {
     JsonNode emailContactsNode = node.get("email_contacts");
-    if (emailContactsNode == null) {
+    if (isNull(emailContactsNode)) {
       emailContactsNode = node.get("emailContacts");
     }
     return emailContactsNode;
@@ -165,7 +165,7 @@ public class DeserializerUtil {
   /** Obtain email label node using snake_case or camelCase notation. */
   public static JsonNode getEmailLabel(@NonNull JsonNode node) {
     JsonNode emailLabelNode = node.get("email_label");
-    if (emailLabelNode == null) {
+    if (isNull(emailLabelNode)) {
       emailLabelNode = node.get("emailLabel");
     }
     return emailLabelNode;
@@ -174,7 +174,7 @@ public class DeserializerUtil {
   /** Obtain enrollment coordinator node using snake_case or camelCase notation. */
   public static JsonNode getEnrollmentCoordinator(@NonNull JsonNode node) {
     JsonNode enrollmentCoordinatorNode = node.get("enrollment_coordinator");
-    if (enrollmentCoordinatorNode == null) {
+    if (isNull(enrollmentCoordinatorNode)) {
       enrollmentCoordinatorNode = node.get("enrollmentCoordinator");
     }
     return enrollmentCoordinatorNode;
@@ -183,7 +183,7 @@ public class DeserializerUtil {
   /** Obtain description facility node using snake_case or camelCase notation. */
   public static JsonNode getFacilityDescription(@NonNull JsonNode node) {
     JsonNode descriptionFacilityNode = node.get("description_facility");
-    if (descriptionFacilityNode == null) {
+    if (isNull(descriptionFacilityNode)) {
       descriptionFacilityNode = node.get("descriptionFacility");
     }
     return descriptionFacilityNode;
@@ -192,7 +192,7 @@ public class DeserializerUtil {
   /** Obtain facility service hours node using snake_case or camelCase notation. */
   public static JsonNode getFacilityServiceHours(@NonNull JsonNode node) {
     JsonNode facilityServiceHoursNode = node.get("facility_service_hours");
-    if (facilityServiceHoursNode == null) {
+    if (isNull(facilityServiceHoursNode)) {
       facilityServiceHoursNode = node.get("facilityServiceHours");
     }
     return facilityServiceHoursNode;
@@ -201,7 +201,7 @@ public class DeserializerUtil {
   /** Obtain facility type node using snake_case or camelCase notation. */
   public static JsonNode getFacilityType(@NonNull JsonNode node) {
     JsonNode facilityTypeNode = node.get("facility_type");
-    if (facilityTypeNode == null) {
+    if (isNull(facilityTypeNode)) {
       facilityTypeNode = node.get("facilityType");
     }
     return facilityTypeNode;
@@ -210,7 +210,7 @@ public class DeserializerUtil {
   /** Obtain friday hours node using snake_case or camelCase notation. */
   public static JsonNode getFridayHours(@NonNull JsonNode node) {
     JsonNode fridayHoursNode = node.get("Friday");
-    if (fridayHoursNode == null) {
+    if (isNull(fridayHoursNode)) {
       fridayHoursNode = node.get("friday");
     }
     return fridayHoursNode;
@@ -219,7 +219,7 @@ public class DeserializerUtil {
   /** Obtain last updated node using snake_case or camelCase notation. */
   public static JsonNode getLastUpdated(@NonNull JsonNode node) {
     JsonNode lastUpdatedNode = node.get("last_updated");
-    if (lastUpdatedNode == null) {
+    if (isNull(lastUpdatedNode)) {
       lastUpdatedNode = node.get("lastUpdated");
     }
     return lastUpdatedNode;
@@ -228,7 +228,7 @@ public class DeserializerUtil {
   /** Obtain mental health clinic node using snake_case or camelCase notation. */
   public static JsonNode getMentalHealthClinic(@NonNull JsonNode node) {
     JsonNode mentalHealthClinicNode = node.get("mental_health_clinic");
-    if (mentalHealthClinicNode == null) {
+    if (isNull(mentalHealthClinicNode)) {
       mentalHealthClinicNode = node.get("mentalHealthClinic");
     }
     return mentalHealthClinicNode;
@@ -237,7 +237,7 @@ public class DeserializerUtil {
   /** Obtain monday hours node using snake_case or camelCase notation. */
   public static JsonNode getMondayHours(@NonNull JsonNode node) {
     JsonNode mondayHoursNode = node.get("Monday");
-    if (mondayHoursNode == null) {
+    if (isNull(mondayHoursNode)) {
       mondayHoursNode = node.get("monday");
     }
     return mondayHoursNode;
@@ -246,7 +246,7 @@ public class DeserializerUtil {
   /** Obtain online scheduling available node using snake_case or camelCase notation. */
   public static JsonNode getOnlineSchedulingAvailable(@NonNull JsonNode node) {
     JsonNode onlineSchedulingAvailableNode = node.get("online_scheduling_available");
-    if (onlineSchedulingAvailableNode == null) {
+    if (isNull(onlineSchedulingAvailableNode)) {
       onlineSchedulingAvailableNode = node.get("onlineSchedulingAvailable");
     }
     return onlineSchedulingAvailableNode;
@@ -256,7 +256,7 @@ public class DeserializerUtil {
   public static JsonNode getOperationalHoursSpecialInstructions(@NonNull JsonNode node) {
     JsonNode operationalHoursSpecialInstructionsNode =
         node.get("operational_hours_special_instructions");
-    if (operationalHoursSpecialInstructionsNode == null) {
+    if (isNull(operationalHoursSpecialInstructionsNode)) {
       operationalHoursSpecialInstructionsNode = node.get("operationalHoursSpecialInstructions");
     }
     return operationalHoursSpecialInstructionsNode;
@@ -265,7 +265,7 @@ public class DeserializerUtil {
   /** Obtain operating status node using snake_case or camelCase notation. */
   public static JsonNode getOpertingStatus(@NonNull JsonNode node) {
     JsonNode operatingStatusNode = node.get("operating_status");
-    if (operatingStatusNode == null) {
+    if (isNull(operatingStatusNode)) {
       operatingStatusNode = node.get("operatingStatus");
     }
     return operatingStatusNode;
@@ -274,7 +274,7 @@ public class DeserializerUtil {
   /** Obtain patient advocate node using snake_case or camelCase notation. */
   public static JsonNode getPatientAdvocate(@NonNull JsonNode node) {
     JsonNode patientAdvocateNode = node.get("patient_advocate");
-    if (patientAdvocateNode == null) {
+    if (isNull(patientAdvocateNode)) {
       patientAdvocateNode = node.get("patientAdvocate");
     }
     return patientAdvocateNode;
@@ -283,7 +283,7 @@ public class DeserializerUtil {
   /** Obtain phone numbers node using snake_case or camelCase notation. */
   public static JsonNode getPhoneNumbers(@NonNull JsonNode node) {
     JsonNode phoneNumbersNode = node.get("appointment_phones");
-    if (phoneNumbersNode == null) {
+    if (isNull(phoneNumbersNode)) {
       phoneNumbersNode = node.get("appointmentPhones");
     }
     return phoneNumbersNode;
@@ -292,7 +292,7 @@ public class DeserializerUtil {
   /** Obtain primary care routine node using snake_case or camelCase notation. */
   public static JsonNode getPrimaryCareRoutine(@NonNull JsonNode node) {
     JsonNode primaryCareRoutineNode = node.get("primary_care_routine");
-    if (primaryCareRoutineNode == null) {
+    if (isNull(primaryCareRoutineNode)) {
       primaryCareRoutineNode = node.get("primaryCareRoutine");
     }
     return primaryCareRoutineNode;
@@ -301,7 +301,7 @@ public class DeserializerUtil {
   /** Obtain primary care urgent node using snake_case or camelCase notation. */
   public static JsonNode getPrimaryCareUrgent(@NonNull JsonNode node) {
     JsonNode primaryCareUrgentNode = node.get("primary_care_urgent");
-    if (primaryCareUrgentNode == null) {
+    if (isNull(primaryCareUrgentNode)) {
       primaryCareUrgentNode = node.get("primaryCareUrgent");
     }
     return primaryCareUrgentNode;
@@ -310,7 +310,7 @@ public class DeserializerUtil {
   /** Obtain referral required node using snake_case or camelCase notation. */
   public static JsonNode getReferralRequired(@NonNull JsonNode node) {
     JsonNode referralRequiredNode = node.get("referral_required");
-    if (referralRequiredNode == null) {
+    if (isNull(referralRequiredNode)) {
       referralRequiredNode = node.get("referralRequired");
     }
     return referralRequiredNode;
@@ -319,7 +319,7 @@ public class DeserializerUtil {
   /** Obtain saturday hours node using snake_case or camelCase notation. */
   public static JsonNode getSaturdayHours(@NonNull JsonNode node) {
     JsonNode saturdayHoursNode = node.get("Saturday");
-    if (saturdayHoursNode == null) {
+    if (isNull(saturdayHoursNode)) {
       saturdayHoursNode = node.get("saturday");
     }
     return saturdayHoursNode;
@@ -328,7 +328,7 @@ public class DeserializerUtil {
   /** Obtain service location address node using snake_case or camelCase notation. */
   public static JsonNode getServiceLocationAddress(@NonNull JsonNode node) {
     JsonNode serviceLocationAddressNode = node.get("service_location_address");
-    if (serviceLocationAddressNode == null) {
+    if (isNull(serviceLocationAddressNode)) {
       serviceLocationAddressNode = node.get("serviceLocationAddress");
     }
     return serviceLocationAddressNode;
@@ -337,7 +337,7 @@ public class DeserializerUtil {
   /** Obtain service locations node using snake_case or camelCase notation. */
   public static JsonNode getServiceLocations(@NonNull JsonNode node) {
     JsonNode serviceLocationsNode = node.get("service_locations");
-    if (serviceLocationsNode == null) {
+    if (isNull(serviceLocationsNode)) {
       serviceLocationsNode = node.get("serviceLocations");
     }
     return serviceLocationsNode;
@@ -346,7 +346,7 @@ public class DeserializerUtil {
   /** Obtain specialty care routine node using snake_case or camelCase notation. */
   public static JsonNode getSpecialtyCareRoutine(@NonNull JsonNode node) {
     JsonNode specialtyCareRoutineNode = node.get("specialty_care_routine");
-    if (specialtyCareRoutineNode == null) {
+    if (isNull(specialtyCareRoutineNode)) {
       specialtyCareRoutineNode = node.get("specialtyCareRoutine");
     }
     return specialtyCareRoutineNode;
@@ -355,7 +355,7 @@ public class DeserializerUtil {
   /** Obtain specialty care urgent node using snake_case or camelCase notation. */
   public static JsonNode getSpecialtyCareUrgent(@NonNull JsonNode node) {
     JsonNode specialtyCareUrgentNode = node.get("specialty_care_urgent");
-    if (specialtyCareUrgentNode == null) {
+    if (isNull(specialtyCareUrgentNode)) {
       specialtyCareUrgentNode = node.get("specialtyCareUrgent");
     }
     return specialtyCareUrgentNode;
@@ -364,7 +364,7 @@ public class DeserializerUtil {
   /** Obtain sunday hours node using snake_case or camelCase notation. */
   public static JsonNode getSundayHours(@NonNull JsonNode node) {
     JsonNode sundayHoursNode = node.get("Sunday");
-    if (sundayHoursNode == null) {
+    if (isNull(sundayHoursNode)) {
       sundayHoursNode = node.get("sunday");
     }
     return sundayHoursNode;
@@ -373,7 +373,7 @@ public class DeserializerUtil {
   /** Obtain thursday hours node using snake_case or camelCase notation. */
   public static JsonNode getThursdayHours(@NonNull JsonNode node) {
     JsonNode thursdayHoursNode = node.get("Thursday");
-    if (thursdayHoursNode == null) {
+    if (isNull(thursdayHoursNode)) {
       thursdayHoursNode = node.get("thursday");
     }
     return thursdayHoursNode;
@@ -382,7 +382,7 @@ public class DeserializerUtil {
   /** Obtain time zone node using snake_case or camelCase notation. */
   public static JsonNode getTimeZone(@NonNull JsonNode node) {
     JsonNode timeZoneNode = node.get("time_zone");
-    if (timeZoneNode == null) {
+    if (isNull(timeZoneNode)) {
       timeZoneNode = node.get("timeZone");
     }
     return timeZoneNode;
@@ -391,7 +391,7 @@ public class DeserializerUtil {
   /** Obtain tuesday hours node using snake_case or camelCase notation. */
   public static JsonNode getTuesdayHours(@NonNull JsonNode node) {
     JsonNode tuesdayHoursNode = node.get("Tuesday");
-    if (tuesdayHoursNode == null) {
+    if (isNull(tuesdayHoursNode)) {
       tuesdayHoursNode = node.get("tuesday");
     }
     return tuesdayHoursNode;
@@ -400,7 +400,7 @@ public class DeserializerUtil {
   /** Obtain wait times node using snake_case or camelCase notation. */
   public static JsonNode getWaitTimes(@NonNull JsonNode node) {
     JsonNode waitTimesNode = node.get("wait_times");
-    if (waitTimesNode == null) {
+    if (isNull(waitTimesNode)) {
       waitTimesNode = node.get("waitTimes");
     }
     return waitTimesNode;
@@ -409,7 +409,7 @@ public class DeserializerUtil {
   /** Obtain walk ins accepted node using snake_case or camelCase notation. */
   public static JsonNode getWalkInsAccepted(@NonNull JsonNode node) {
     JsonNode walkInsAcceptedNode = node.get("walk_ins_accepted");
-    if (walkInsAcceptedNode == null) {
+    if (isNull(walkInsAcceptedNode)) {
       walkInsAcceptedNode = node.get("walkInsAccepted");
     }
     return walkInsAcceptedNode;
@@ -418,7 +418,7 @@ public class DeserializerUtil {
   /** Obtain wednesday hours node using snake_case or camelCase notation. */
   public static JsonNode getWednesdayHours(@NonNull JsonNode node) {
     JsonNode wednesdayHoursNode = node.get("Wednesday");
-    if (wednesdayHoursNode == null) {
+    if (isNull(wednesdayHoursNode)) {
       wednesdayHoursNode = node.get("wednesday");
     }
     return wednesdayHoursNode;
@@ -427,7 +427,7 @@ public class DeserializerUtil {
   /** Obtain wing, floor, or room number node using snake_case or camelCase notation. */
   public static JsonNode getWingFloorOrRoomNumber(@NonNull JsonNode node) {
     JsonNode wingFloorOrRoomNumberNode = node.get("wing_floor_or_room_number");
-    if (wingFloorOrRoomNumberNode == null) {
+    if (isNull(wingFloorOrRoomNumberNode)) {
       wingFloorOrRoomNumberNode = node.get("wingFloorOrRoomNumber");
     }
     return wingFloorOrRoomNumberNode;
@@ -436,9 +436,13 @@ public class DeserializerUtil {
   /** Obtain zip code node using snake_case or camelCase notation. */
   public static JsonNode getZipCode(@NonNull JsonNode node) {
     JsonNode zipCodeNode = node.get("zip_code");
-    if (zipCodeNode == null) {
+    if (isNull(zipCodeNode)) {
       zipCodeNode = node.get("zipCode");
     }
     return zipCodeNode;
+  }
+
+  private static boolean isNull(JsonNode node) {
+    return node == null || node.isNull();
   }
 }

--- a/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/common/deserializers/BaseDeserializer.java
+++ b/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/common/deserializers/BaseDeserializer.java
@@ -1,0 +1,27 @@
+package gov.va.api.lighthouse.facilities.api.common.deserializers;
+
+import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+public abstract class BaseDeserializer<T> extends StdDeserializer<T> {
+  protected static final ObjectMapper MAPPER = createMapper();
+
+  public BaseDeserializer(Class<T> t) {
+    super(t);
+  }
+
+  public abstract T deserialize(JsonParser jp, DeserializationContext deserializationContext);
+
+  protected boolean isNotNull(JsonNode node) {
+    return !isNull(node);
+  }
+
+  protected boolean isNull(JsonNode node) {
+    return node == null || node.isNull();
+  }
+}

--- a/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v0/Facility.java
+++ b/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v0/Facility.java
@@ -56,7 +56,15 @@ public final class Facility {
     TransitionAssistance,
     UpdatingDirectDepositInformation,
     VAHomeLoanAssistance,
-    VocationalRehabilitationAndEmploymentAssistance
+    VocationalRehabilitationAndEmploymentAssistance;
+
+    /** Ensure that Jackson can create BenefitsService enum regardless of capitalization. */
+    @JsonCreator
+    public static BenefitsService fromString(String name) {
+      return eBenefitsRegistrationAssistance.name().equalsIgnoreCase(name)
+          ? eBenefitsRegistrationAssistance
+          : valueOf(capitalize(name));
+    }
   }
 
   public enum FacilityType {
@@ -92,12 +100,10 @@ public final class Facility {
     @JsonCreator
     public static HealthService fromString(String name) {
       return "COVID-19 vaccines".equalsIgnoreCase(name)
-          ? HealthService.Covid19Vaccine
+          ? Covid19Vaccine
           : "mentalHealth".equalsIgnoreCase(name)
-              ? HealthService.MentalHealthCare
-              : "dental".equalsIgnoreCase(name)
-                  ? HealthService.DentalServices
-                  : valueOf(capitalize(name));
+              ? MentalHealthCare
+              : "dental".equalsIgnoreCase(name) ? DentalServices : valueOf(capitalize(name));
     }
   }
 

--- a/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v0/deserializers/BaseListDeserializer.java
+++ b/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v0/deserializers/BaseListDeserializer.java
@@ -4,16 +4,12 @@ import static gov.va.api.lighthouse.facilities.api.v0.DetailedService.INVALID_SV
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import gov.va.api.lighthouse.facilities.api.common.deserializers.BaseDeserializer;
 import gov.va.api.lighthouse.facilities.api.v0.DetailedService;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public abstract class BaseListDeserializer<T> extends StdDeserializer<T> {
-  public BaseListDeserializer() {
-    this(null);
-  }
-
+public abstract class BaseListDeserializer<T> extends BaseDeserializer<T> {
   public BaseListDeserializer(Class<T> t) {
     super(t);
   }

--- a/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v0/deserializers/CmsOverlayDeserializer.java
+++ b/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v0/deserializers/CmsOverlayDeserializer.java
@@ -1,11 +1,9 @@
 package gov.va.api.lighthouse.facilities.api.v0.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getDetailedServices;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getOpertingStatus;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -27,10 +25,8 @@ public class CmsOverlayDeserializer extends BaseListDeserializer<CmsOverlay> {
   @Override
   @SneakyThrows
   @SuppressWarnings("unchecked")
-  public CmsOverlay deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+  public CmsOverlay deserialize(JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode operatingStatusNode = getOpertingStatus(node);
@@ -40,13 +36,13 @@ public class CmsOverlayDeserializer extends BaseListDeserializer<CmsOverlay> {
 
     return CmsOverlay.builder()
         .operatingStatus(
-            operatingStatusNode != null
-                ? createMapper().convertValue(operatingStatusNode, OperatingStatus.class)
+            isNotNull(operatingStatusNode)
+                ? MAPPER.convertValue(operatingStatusNode, OperatingStatus.class)
                 : null)
         .detailedServices(
-            detailedServicesNode != null
+            isNotNull(detailedServicesNode)
                 ? filterOutInvalidDetailedServices(
-                    createMapper().convertValue(detailedServicesNode, detailedServicesRef))
+                    MAPPER.convertValue(detailedServicesNode, detailedServicesRef))
                 : null)
         .build();
   }

--- a/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v0/deserializers/DetailedServiceDeserializer.java
+++ b/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v0/deserializers/DetailedServiceDeserializer.java
@@ -1,6 +1,5 @@
 package gov.va.api.lighthouse.facilities.api.v0.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getAppointmentLeadin;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getFacilityDescription;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getOnlineSchedulingAvailable;
@@ -9,15 +8,13 @@ import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getReferralR
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getServiceLocations;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getWalkInsAccepted;
 import static gov.va.api.lighthouse.facilities.api.v0.DetailedService.INVALID_SVC_ID;
-import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.uncapitalize;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import gov.va.api.lighthouse.facilities.api.common.deserializers.BaseDeserializer;
 import gov.va.api.lighthouse.facilities.api.v0.DetailedService;
 import gov.va.api.lighthouse.facilities.api.v0.DetailedService.AppointmentPhoneNumber;
 import gov.va.api.lighthouse.facilities.api.v0.DetailedService.DetailedServiceLocation;
@@ -29,7 +26,7 @@ import java.util.List;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
 
-public class DetailedServiceDeserializer extends StdDeserializer<DetailedService> {
+public class DetailedServiceDeserializer extends BaseDeserializer<DetailedService> {
   public DetailedServiceDeserializer() {
     this(null);
   }
@@ -41,10 +38,8 @@ public class DetailedServiceDeserializer extends StdDeserializer<DetailedService
   @Override
   @SneakyThrows
   @SuppressWarnings("unchecked")
-  public DetailedService deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+  public DetailedService deserialize(JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode nameNode = node.get("name");
@@ -60,14 +55,12 @@ public class DetailedServiceDeserializer extends StdDeserializer<DetailedService
     JsonNode serviceLocationsNode = getServiceLocations(node);
     JsonNode walkInsAcceptedNode = getWalkInsAccepted(node);
 
-    String serviceName =
-        nameNode != null ? createMapper().convertValue(nameNode, String.class) : null;
+    String serviceName = isNotNull(nameNode) ? nameNode.asText() : null;
     String serviceId =
-        serviceIdNode != null
-                && isRecognizedServiceId(createMapper().convertValue(serviceIdNode, String.class))
-            ? createMapper().convertValue(serviceIdNode, String.class)
+        isNotNull(serviceIdNode) && isRecognizedServiceId(serviceIdNode.asText())
+            ? serviceIdNode.asText()
             : // Attempt to construct service id from service name
-            serviceIdNode == null && isRecognizedServiceName(serviceName)
+            isNull(serviceIdNode) && isRecognizedServiceName(serviceName)
                 ? getServiceIdForRecognizedServiceName(serviceName)
                 : INVALID_SVC_ID;
 
@@ -77,38 +70,26 @@ public class DetailedServiceDeserializer extends StdDeserializer<DetailedService
     return DetailedService.builder()
         .serviceId(serviceId)
         .name(serviceName)
-        .active(activeNode != null ? createMapper().convertValue(activeNode, Boolean.class) : false)
-        .changed(
-            changedNode != null ? createMapper().convertValue(changedNode, String.class) : null)
+        .active(isNotNull(activeNode) ? activeNode.asBoolean() : false)
+        .changed(isNotNull(changedNode) ? changedNode.asText() : null)
         .descriptionFacility(
-            descriptionFacilityNode != null
-                ? createMapper().convertValue(descriptionFacilityNode, String.class)
-                : null)
-        .appointmentLeadIn(
-            appointmentLeadInNode != null
-                ? createMapper().convertValue(appointmentLeadInNode, String.class)
-                : null)
+            isNotNull(descriptionFacilityNode) ? descriptionFacilityNode.asText() : null)
+        .appointmentLeadIn(isNotNull(appointmentLeadInNode) ? appointmentLeadInNode.asText() : null)
         .onlineSchedulingAvailable(
-            onlineSchedulingAvailableNode != null
-                ? createMapper().convertValue(onlineSchedulingAvailableNode, String.class)
+            isNotNull(onlineSchedulingAvailableNode)
+                ? onlineSchedulingAvailableNode.asText()
                 : null)
-        .path(pathNode != null ? createMapper().convertValue(pathNode, String.class) : null)
+        .path(isNotNull(pathNode) ? pathNode.asText() : null)
         .phoneNumbers(
-            phoneNumbersNode != null
-                ? createMapper().convertValue(phoneNumbersNode, appointmentNumbersRef)
-                : emptyList())
-        .referralRequired(
-            referralRequiredNode != null
-                ? createMapper().convertValue(referralRequiredNode, String.class)
+            isNotNull(phoneNumbersNode)
+                ? MAPPER.convertValue(phoneNumbersNode, appointmentNumbersRef)
                 : null)
+        .referralRequired(isNotNull(referralRequiredNode) ? referralRequiredNode.asText() : null)
         .serviceLocations(
-            serviceLocationsNode != null
-                ? createMapper().convertValue(serviceLocationsNode, serviceLocationsRef)
-                : emptyList())
-        .walkInsAccepted(
-            walkInsAcceptedNode != null
-                ? createMapper().convertValue(walkInsAcceptedNode, String.class)
+            isNotNull(serviceLocationsNode)
+                ? MAPPER.convertValue(serviceLocationsNode, serviceLocationsRef)
                 : null)
+        .walkInsAccepted(isNotNull(walkInsAcceptedNode) ? walkInsAcceptedNode.asText() : null)
         .build();
   }
 
@@ -123,7 +104,7 @@ public class DetailedServiceDeserializer extends StdDeserializer<DetailedService
                 : Arrays.stream(BenefitsService.values())
                         .parallel()
                         .anyMatch(bs -> bs.name().equalsIgnoreCase(name))
-                    ? BenefitsService.valueOf(name).name()
+                    ? BenefitsService.fromString(name).name()
                     : Arrays.stream(OtherService.values())
                             .parallel()
                             .anyMatch(os -> os.name().equalsIgnoreCase(name))

--- a/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v0/deserializers/DetailedServicesResponseDeserializer.java
+++ b/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v0/deserializers/DetailedServicesResponseDeserializer.java
@@ -1,9 +1,6 @@
 package gov.va.api.lighthouse.facilities.api.v0.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
-
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -28,9 +25,8 @@ public class DetailedServicesResponseDeserializer
   @SneakyThrows
   @SuppressWarnings("unchecked")
   public DetailedServicesResponse deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+      JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode dataNode = node.get("data");
@@ -41,14 +37,14 @@ public class DetailedServicesResponseDeserializer
 
     return DetailedServicesResponse.builder()
         .data(
-            dataNode != null
+            isNotNull(dataNode)
                 ? filterOutInvalidDetailedServices(
-                    createMapper().convertValue(dataNode, detailedServicesRef))
+                    MAPPER.convertValue(dataNode, detailedServicesRef))
                 : null)
-        .links(linksNode != null ? createMapper().convertValue(linksNode, PageLinks.class) : null)
+        .links(isNotNull(linksNode) ? MAPPER.convertValue(linksNode, PageLinks.class) : null)
         .meta(
-            metaNode != null
-                ? createMapper().convertValue(metaNode, DetailedServicesMetadata.class)
+            isNotNull(metaNode)
+                ? MAPPER.convertValue(metaNode, DetailedServicesMetadata.class)
                 : null)
         .build();
   }

--- a/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v0/deserializers/FacilityAttributesDeserializer.java
+++ b/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v0/deserializers/FacilityAttributesDeserializer.java
@@ -1,6 +1,5 @@
 package gov.va.api.lighthouse.facilities.api.v0.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getActiveStatus;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getDetailedServices;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getFacilityType;
@@ -10,7 +9,6 @@ import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getTimeZone;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getWaitTimes;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -42,9 +40,8 @@ public class FacilityAttributesDeserializer extends BaseListDeserializer<Facilit
   @SneakyThrows
   @SuppressWarnings("unchecked")
   public FacilityAttributes deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+      JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode nameNode = node.get("name");
@@ -70,60 +67,48 @@ public class FacilityAttributesDeserializer extends BaseListDeserializer<Facilit
     TypeReference<List<DetailedService>> detailedServicesRef = new TypeReference<>() {};
 
     return FacilityAttributes.builder()
-        .name(nameNode != null ? createMapper().convertValue(nameNode, String.class) : null)
+        .name(isNotNull(nameNode) ? nameNode.asText() : null)
         .facilityType(
-            facilityTypeNode != null
-                ? createMapper().convertValue(facilityTypeNode, FacilityType.class)
+            isNotNull(facilityTypeNode)
+                ? MAPPER.convertValue(facilityTypeNode, FacilityType.class)
                 : null)
-        .classification(
-            classificationNode != null
-                ? createMapper().convertValue(classificationNode, String.class)
-                : null)
-        .website(
-            websiteNode != null ? createMapper().convertValue(websiteNode, String.class) : null)
+        .classification(isNotNull(classificationNode) ? classificationNode.asText() : null)
+        .website(isNotNull(websiteNode) ? websiteNode.asText() : null)
         .latitude(
-            latitudeNode != null
-                ? createMapper().convertValue(latitudeNode, BigDecimal.class)
-                : null)
+            isNotNull(latitudeNode) ? MAPPER.convertValue(latitudeNode, BigDecimal.class) : null)
         .longitude(
-            longitudeNode != null
-                ? createMapper().convertValue(longitudeNode, BigDecimal.class)
-                : null)
-        .timeZone(
-            timeZoneNode != null ? createMapper().convertValue(timeZoneNode, String.class) : null)
-        .address(
-            addressNode != null ? createMapper().convertValue(addressNode, Addresses.class) : null)
-        .phone(phoneNode != null ? createMapper().convertValue(phoneNode, Phone.class) : null)
-        .hours(hoursNode != null ? createMapper().convertValue(hoursNode, Hours.class) : null)
+            isNotNull(longitudeNode) ? MAPPER.convertValue(longitudeNode, BigDecimal.class) : null)
+        .timeZone(isNotNull(timeZoneNode) ? timeZoneNode.asText() : null)
+        .address(isNotNull(addressNode) ? MAPPER.convertValue(addressNode, Addresses.class) : null)
+        .phone(isNotNull(phoneNode) ? MAPPER.convertValue(phoneNode, Phone.class) : null)
+        .hours(isNotNull(hoursNode) ? MAPPER.convertValue(hoursNode, Hours.class) : null)
         .operationalHoursSpecialInstructions(
-            operationalHoursSpecialInstructionsNode != null
-                ? createMapper().convertValue(operationalHoursSpecialInstructionsNode, String.class)
+            isNotNull(operationalHoursSpecialInstructionsNode)
+                ? operationalHoursSpecialInstructionsNode.asText()
                 : null)
         .services(
-            servicesNode != null ? createMapper().convertValue(servicesNode, Services.class) : null)
+            isNotNull(servicesNode) ? MAPPER.convertValue(servicesNode, Services.class) : null)
         .satisfaction(
-            satisfactionNode != null
-                ? createMapper().convertValue(satisfactionNode, Satisfaction.class)
+            isNotNull(satisfactionNode)
+                ? MAPPER.convertValue(satisfactionNode, Satisfaction.class)
                 : null)
         .waitTimes(
-            waitTimesNode != null
-                ? createMapper().convertValue(waitTimesNode, WaitTimes.class)
-                : null)
-        .mobile(mobileNode != null ? createMapper().convertValue(mobileNode, Boolean.class) : null)
+            isNotNull(waitTimesNode) ? MAPPER.convertValue(waitTimesNode, WaitTimes.class) : null)
+        .mobile(isNotNull(mobileNode) ? mobileNode.asBoolean() : null)
         .activeStatus(
-            activeStatusNode != null
-                ? createMapper().convertValue(activeStatusNode, ActiveStatus.class)
+            isNotNull(activeStatusNode)
+                ? MAPPER.convertValue(activeStatusNode, ActiveStatus.class)
                 : null)
         .operatingStatus(
-            operatingStatusNode != null
-                ? createMapper().convertValue(operatingStatusNode, OperatingStatus.class)
+            isNotNull(operatingStatusNode)
+                ? MAPPER.convertValue(operatingStatusNode, OperatingStatus.class)
                 : null)
         .detailedServices(
-            detailedServicesNode != null
+            isNotNull(detailedServicesNode)
                 ? filterOutInvalidDetailedServices(
-                    createMapper().convertValue(detailedServicesNode, detailedServicesRef))
+                    MAPPER.convertValue(detailedServicesNode, detailedServicesRef))
                 : null)
-        .visn(visnNode != null ? createMapper().convertValue(visnNode, String.class) : null)
+        .visn(isNotNull(visnNode) ? visnNode.asText() : null)
         .build();
   }
 }

--- a/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v0/deserializers/GeoFacilityPropertiesDeserializer.java
+++ b/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v0/deserializers/GeoFacilityPropertiesDeserializer.java
@@ -1,6 +1,5 @@
 package gov.va.api.lighthouse.facilities.api.v0.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getActiveStatus;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getDetailedServices;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getFacilityType;
@@ -10,7 +9,6 @@ import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getTimeZone;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getWaitTimes;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -40,10 +38,8 @@ public class GeoFacilityPropertiesDeserializer extends BaseListDeserializer<Prop
   @Override
   @SneakyThrows
   @SuppressWarnings("unchecked")
-  public Properties deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+  public Properties deserialize(JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode idNode = node.get("id");
@@ -68,53 +64,45 @@ public class GeoFacilityPropertiesDeserializer extends BaseListDeserializer<Prop
     TypeReference<List<DetailedService>> detailedServicesRef = new TypeReference<>() {};
 
     return Properties.builder()
-        .id(idNode != null ? createMapper().convertValue(idNode, String.class) : null)
-        .name(nameNode != null ? createMapper().convertValue(nameNode, String.class) : null)
+        .id(isNotNull(idNode) ? idNode.asText() : null)
+        .name(isNotNull(nameNode) ? nameNode.asText() : null)
         .facilityType(
-            facilityTypeNode != null
-                ? createMapper().convertValue(facilityTypeNode, FacilityType.class)
+            isNotNull(facilityTypeNode)
+                ? MAPPER.convertValue(facilityTypeNode, FacilityType.class)
                 : null)
-        .classification(
-            classificationNode != null
-                ? createMapper().convertValue(classificationNode, String.class)
-                : null)
-        .website(
-            websiteNode != null ? createMapper().convertValue(websiteNode, String.class) : null)
-        .timeZone(
-            timeZoneNode != null ? createMapper().convertValue(timeZoneNode, String.class) : null)
-        .address(
-            addressNode != null ? createMapper().convertValue(addressNode, Addresses.class) : null)
-        .phone(phoneNode != null ? createMapper().convertValue(phoneNode, Phone.class) : null)
-        .hours(hoursNode != null ? createMapper().convertValue(hoursNode, Hours.class) : null)
+        .classification(isNotNull(classificationNode) ? classificationNode.asText() : null)
+        .website(isNotNull(websiteNode) ? websiteNode.asText() : null)
+        .timeZone(isNotNull(timeZoneNode) ? timeZoneNode.asText() : null)
+        .address(isNotNull(addressNode) ? MAPPER.convertValue(addressNode, Addresses.class) : null)
+        .phone(isNotNull(phoneNode) ? MAPPER.convertValue(phoneNode, Phone.class) : null)
+        .hours(isNotNull(hoursNode) ? MAPPER.convertValue(hoursNode, Hours.class) : null)
         .operationalHoursSpecialInstructions(
-            operationalHoursSpecialInstructionsNode != null
-                ? createMapper().convertValue(operationalHoursSpecialInstructionsNode, String.class)
+            isNotNull(operationalHoursSpecialInstructionsNode)
+                ? operationalHoursSpecialInstructionsNode.asText()
                 : null)
         .services(
-            servicesNode != null ? createMapper().convertValue(servicesNode, Services.class) : null)
+            isNotNull(servicesNode) ? MAPPER.convertValue(servicesNode, Services.class) : null)
         .satisfaction(
-            satisfactionNode != null
-                ? createMapper().convertValue(satisfactionNode, Satisfaction.class)
+            isNotNull(satisfactionNode)
+                ? MAPPER.convertValue(satisfactionNode, Satisfaction.class)
                 : null)
         .waitTimes(
-            waitTimesNode != null
-                ? createMapper().convertValue(waitTimesNode, WaitTimes.class)
-                : null)
-        .mobile(mobileNode != null ? createMapper().convertValue(mobileNode, Boolean.class) : null)
+            isNotNull(waitTimesNode) ? MAPPER.convertValue(waitTimesNode, WaitTimes.class) : null)
+        .mobile(isNotNull(mobileNode) ? mobileNode.asBoolean() : null)
         .activeStatus(
-            activeStatusNode != null
-                ? createMapper().convertValue(activeStatusNode, ActiveStatus.class)
+            isNotNull(activeStatusNode)
+                ? MAPPER.convertValue(activeStatusNode, ActiveStatus.class)
                 : null)
         .operatingStatus(
-            operatingStatusNode != null
-                ? createMapper().convertValue(operatingStatusNode, OperatingStatus.class)
+            isNotNull(operatingStatusNode)
+                ? MAPPER.convertValue(operatingStatusNode, OperatingStatus.class)
                 : null)
         .detailedServices(
-            detailedServicesNode != null
+            isNotNull(detailedServicesNode)
                 ? filterOutInvalidDetailedServices(
-                    createMapper().convertValue(detailedServicesNode, detailedServicesRef))
+                    MAPPER.convertValue(detailedServicesNode, detailedServicesRef))
                 : null)
-        .visn(visnNode != null ? createMapper().convertValue(visnNode, String.class) : null)
+        .visn(isNotNull(visnNode) ? visnNode.asText() : null)
         .build();
   }
 }

--- a/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v1/Facility.java
+++ b/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v1/Facility.java
@@ -74,7 +74,15 @@ public final class Facility implements CanBeEmpty {
     TransitionAssistance,
     UpdatingDirectDepositInformation,
     VAHomeLoanAssistance,
-    VocationalRehabilitationAndEmploymentAssistance
+    VocationalRehabilitationAndEmploymentAssistance;
+
+    /** Ensure that Jackson can create BenefitsService enum regardless of capitalization. */
+    @JsonCreator
+    public static BenefitsService fromString(String name) {
+      return eBenefitsRegistrationAssistance.name().equalsIgnoreCase(name)
+          ? eBenefitsRegistrationAssistance
+          : valueOf(capitalize(name));
+    }
   }
 
   public enum FacilityType {
@@ -292,12 +300,10 @@ public final class Facility implements CanBeEmpty {
     @JsonCreator
     public static HealthService fromString(String name) {
       return "COVID-19 vaccines".equalsIgnoreCase(name)
-          ? HealthService.Covid19Vaccine
+          ? Covid19Vaccine
           : "MentalHealthCare".equalsIgnoreCase(name)
-              ? HealthService.MentalHealth
-              : "DentalServices".equalsIgnoreCase(name)
-                  ? HealthService.Dental
-                  : valueOf(capitalize(name));
+              ? MentalHealth
+              : "DentalServices".equalsIgnoreCase(name) ? Dental : valueOf(capitalize(name));
     }
   }
 

--- a/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v1/deserializers/BaseListDeserializer.java
+++ b/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v1/deserializers/BaseListDeserializer.java
@@ -4,22 +4,17 @@ import static gov.va.api.lighthouse.facilities.api.v1.DetailedService.INVALID_SV
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import gov.va.api.lighthouse.facilities.api.common.deserializers.BaseDeserializer;
 import gov.va.api.lighthouse.facilities.api.v1.DetailedService;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public abstract class BaseListDeserializer<T> extends StdDeserializer<T> {
-  public BaseListDeserializer() {
-    this(null);
-  }
-
+public abstract class BaseListDeserializer<T> extends BaseDeserializer<T> {
   public BaseListDeserializer(Class<T> t) {
     super(t);
   }
 
-  public abstract T deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext);
+  public abstract T deserialize(JsonParser jp, DeserializationContext deserializationContext);
 
   /** Filter out any detailed services with an invalid service id. */
   protected List<DetailedService> filterOutInvalidDetailedServices(

--- a/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v1/deserializers/CmsOverlayDeserializer.java
+++ b/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v1/deserializers/CmsOverlayDeserializer.java
@@ -1,11 +1,9 @@
 package gov.va.api.lighthouse.facilities.api.v1.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getDetailedServices;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getOpertingStatus;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -27,10 +25,8 @@ public class CmsOverlayDeserializer extends BaseListDeserializer<CmsOverlay> {
   @Override
   @SneakyThrows
   @SuppressWarnings("unchecked")
-  public CmsOverlay deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+  public CmsOverlay deserialize(JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode operatingStatusNode = getOpertingStatus(node);
@@ -40,13 +36,13 @@ public class CmsOverlayDeserializer extends BaseListDeserializer<CmsOverlay> {
 
     return CmsOverlay.builder()
         .operatingStatus(
-            operatingStatusNode != null
-                ? createMapper().convertValue(operatingStatusNode, Facility.OperatingStatus.class)
+            isNotNull(operatingStatusNode)
+                ? MAPPER.convertValue(operatingStatusNode, Facility.OperatingStatus.class)
                 : null)
         .detailedServices(
-            detailedServicesNode != null
+            isNotNull(detailedServicesNode)
                 ? filterOutInvalidDetailedServices(
-                    createMapper().convertValue(detailedServicesNode, detailedServicesRef))
+                    MAPPER.convertValue(detailedServicesNode, detailedServicesRef))
                 : null)
         .build();
   }

--- a/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v1/deserializers/DetailedServicesResponseDeserializer.java
+++ b/facilities-api/src/main/java/gov/va/api/lighthouse/facilities/api/v1/deserializers/DetailedServicesResponseDeserializer.java
@@ -1,9 +1,6 @@
 package gov.va.api.lighthouse.facilities.api.v1.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
-
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -28,9 +25,8 @@ public class DetailedServicesResponseDeserializer
   @SneakyThrows
   @SuppressWarnings("unchecked")
   public DetailedServicesResponse deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+      JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode dataNode = node.get("data");
@@ -41,14 +37,14 @@ public class DetailedServicesResponseDeserializer
 
     return DetailedServicesResponse.builder()
         .data(
-            dataNode != null
+            isNotNull(dataNode)
                 ? filterOutInvalidDetailedServices(
-                    createMapper().convertValue(dataNode, detailedServicesRef))
+                    MAPPER.convertValue(dataNode, detailedServicesRef))
                 : null)
-        .links(linksNode != null ? createMapper().convertValue(linksNode, PageLinks.class) : null)
+        .links(isNotNull(linksNode) ? MAPPER.convertValue(linksNode, PageLinks.class) : null)
         .meta(
-            metaNode != null
-                ? createMapper().convertValue(metaNode, DetailedServicesMetadata.class)
+            isNotNull(metaNode)
+                ? MAPPER.convertValue(metaNode, DetailedServicesMetadata.class)
                 : null)
         .build();
   }

--- a/facilities-api/src/test/java/gov/va/api/lighthouse/facilities/api/DeserializerUtilTest.java
+++ b/facilities-api/src/test/java/gov/va/api/lighthouse/facilities/api/DeserializerUtilTest.java
@@ -1,7 +1,6 @@
 package gov.va.api.lighthouse.facilities.api;
 
 import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
-import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -262,6 +261,14 @@ public class DeserializerUtilTest {
   @Test
   @SneakyThrows
   void detailedServices() {
+    var detailedServicesV0 =
+        gov.va.api.lighthouse.facilities.api.v0.DetailedService.builder()
+            .serviceId(gov.va.api.lighthouse.facilities.api.v0.DetailedService.INVALID_SVC_ID)
+            .build();
+    var detailedServicesV1 =
+        gov.va.api.lighthouse.facilities.api.v1.DetailedService.builder()
+            .serviceId(gov.va.api.lighthouse.facilities.api.v1.DetailedService.INVALID_SVC_ID)
+            .build();
     JsonNode detailedServices =
         DeserializerUtil.getDetailedServices(generateNode("{\"detailed_services\":\"[]\"}"));
     assertThat(detailedServices).isNotNull();
@@ -271,12 +278,7 @@ public class DeserializerUtilTest {
                     detailedServices,
                     gov.va.api.lighthouse.facilities.api.v0.DetailedService.class))
         .usingRecursiveComparison()
-        .isEqualTo(
-            gov.va.api.lighthouse.facilities.api.v0.DetailedService.builder()
-                .serviceId(gov.va.api.lighthouse.facilities.api.v0.DetailedService.INVALID_SVC_ID)
-                .phoneNumbers(emptyList())
-                .serviceLocations(emptyList())
-                .build());
+        .isEqualTo(detailedServicesV0);
     detailedServices =
         DeserializerUtil.getDetailedServices(generateNode("{\"detailedServices\":\"[]\"}"));
     assertThat(detailedServices).isNotNull();
@@ -286,12 +288,7 @@ public class DeserializerUtilTest {
                     detailedServices,
                     gov.va.api.lighthouse.facilities.api.v0.DetailedService.class))
         .usingRecursiveComparison()
-        .isEqualTo(
-            gov.va.api.lighthouse.facilities.api.v0.DetailedService.builder()
-                .serviceId(gov.va.api.lighthouse.facilities.api.v0.DetailedService.INVALID_SVC_ID)
-                .phoneNumbers(emptyList())
-                .serviceLocations(emptyList())
-                .build());
+        .isEqualTo(detailedServicesV0);
     detailedServices =
         DeserializerUtil.getDetailedServices(generateNode("{\"detailed_services\":\"[]\"}"));
     assertThat(detailedServices).isNotNull();
@@ -301,12 +298,7 @@ public class DeserializerUtilTest {
                     detailedServices,
                     gov.va.api.lighthouse.facilities.api.v1.DetailedService.class))
         .usingRecursiveComparison()
-        .isEqualTo(
-            gov.va.api.lighthouse.facilities.api.v1.DetailedService.builder()
-                .serviceId(gov.va.api.lighthouse.facilities.api.v1.DetailedService.INVALID_SVC_ID)
-                .phoneNumbers(emptyList())
-                .serviceLocations(emptyList())
-                .build());
+        .isEqualTo(detailedServicesV1);
     detailedServices =
         DeserializerUtil.getDetailedServices(generateNode("{\"detailedServices\":\"[]\"}"));
     assertThat(detailedServices).isNotNull();
@@ -316,12 +308,7 @@ public class DeserializerUtilTest {
                     detailedServices,
                     gov.va.api.lighthouse.facilities.api.v1.DetailedService.class))
         .usingRecursiveComparison()
-        .isEqualTo(
-            gov.va.api.lighthouse.facilities.api.v1.DetailedService.builder()
-                .serviceId(gov.va.api.lighthouse.facilities.api.v1.DetailedService.INVALID_SVC_ID)
-                .phoneNumbers(emptyList())
-                .serviceLocations(emptyList())
-                .build());
+        .isEqualTo(detailedServicesV1);
     // Exceptions
     assertThatThrownBy(() -> DeserializerUtil.getDetailedServices(null))
         .isInstanceOf(NullPointerException.class)

--- a/facilities-api/src/test/java/gov/va/api/lighthouse/facilities/api/v0/deserializers/DeserializerTest.java
+++ b/facilities-api/src/test/java/gov/va/api/lighthouse/facilities/api/v0/deserializers/DeserializerTest.java
@@ -37,8 +37,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(BenefitsService.Pensions.name()))
                         .name(BenefitsService.Pensions.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -47,6 +45,16 @@ public class DeserializerTest {
         "{\"detailed_services\":[" + "{\"serviceId\":\"pensions\",\"name\":\"Pensions\"}" + "]}",
         CmsOverlay.class,
         overlay);
+    overlay =
+        CmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":[" + "{\"name\":\"Pensions\",\"appointment_phones\":[]}" + "]}",
         CmsOverlay.class,
@@ -57,6 +65,17 @@ public class DeserializerTest {
             + "]}",
         CmsOverlay.class,
         overlay);
+    overlay =
+        CmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Pensions\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -78,14 +97,18 @@ public class DeserializerTest {
         DetailedService.builder()
             .serviceId(uncapitalize(BenefitsService.Pensions.name()))
             .name(BenefitsService.Pensions.name())
-            .phoneNumbers(emptyList())
-            .serviceLocations(emptyList())
             .build();
     assertJson("{\"name\":\"Pensions\"}", DetailedService.class, detailedService);
     assertJson(
         "{\"serviceId\":\"pensions\",\"name\":\"Pensions\"}",
         DetailedService.class,
         detailedService);
+    detailedService =
+        DetailedService.builder()
+            .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+            .name(BenefitsService.Pensions.name())
+            .phoneNumbers(emptyList())
+            .build();
     assertJson(
         "{\"name\":\"Pensions\",\"appointment_phones\":[]}",
         DetailedService.class,
@@ -94,6 +117,13 @@ public class DeserializerTest {
         "{\"serviceId\":\"pensions\",\"name\":\"Pensions\",\"appointment_phones\":[]}",
         DetailedService.class,
         detailedService);
+    detailedService =
+        DetailedService.builder()
+            .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+            .name(BenefitsService.Pensions.name())
+            .phoneNumbers(emptyList())
+            .serviceLocations(emptyList())
+            .build();
     assertJson(
         "{\"name\":\"Pensions\",\"appointment_phones\":[],\"service_locations\":[]}",
         DetailedService.class,
@@ -115,8 +145,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(BenefitsService.Pensions.name()))
                         .name(BenefitsService.Pensions.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -125,6 +153,16 @@ public class DeserializerTest {
         "{\"data\":[" + "{\"serviceId\":\"pensions\",\"name\":\"Pensions\"}" + "]}",
         DetailedServicesResponse.class,
         response);
+    response =
+        DetailedServicesResponse.builder()
+            .data(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"data\":[" + "{\"name\":\"Pensions\",\"appointment_phones\":[]}" + "]}",
         DetailedServicesResponse.class,
@@ -135,6 +173,17 @@ public class DeserializerTest {
             + "]}",
         DetailedServicesResponse.class,
         response);
+    response =
+        DetailedServicesResponse.builder()
+            .data(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"data\":["
             + "{\"name\":\"Pensions\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -160,8 +209,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(BenefitsService.Pensions.name()))
                         .name(BenefitsService.Pensions.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -172,6 +219,16 @@ public class DeserializerTest {
         "{\"detailed_services\":[" + "{\"serviceId\":\"pensions\",\"name\":\"Pensions\"}" + "]}",
         FacilityAttributes.class,
         attributes);
+    attributes =
+        FacilityAttributes.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":[" + "{\"name\":\"Pensions\",\"appointment_phones\":[]}" + "]}",
         FacilityAttributes.class,
@@ -182,6 +239,17 @@ public class DeserializerTest {
             + "]}",
         FacilityAttributes.class,
         attributes);
+    attributes =
+        FacilityAttributes.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Pensions\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -207,8 +275,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(BenefitsService.Pensions.name()))
                         .name(BenefitsService.Pensions.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -219,6 +285,16 @@ public class DeserializerTest {
         "{\"detailed_services\":[" + "{\"serviceId\":\"pensions\",\"name\":\"Pensions\"}" + "]}",
         Properties.class,
         properties);
+    properties =
+        Properties.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":[" + "{\"name\":\"Pensions\",\"appointment_phones\":[]}" + "]}",
         Properties.class,
@@ -229,6 +305,17 @@ public class DeserializerTest {
             + "]}",
         Properties.class,
         properties);
+    properties =
+        Properties.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Pensions\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -296,14 +383,10 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(BenefitsService.Pensions.name()))
                         .name(BenefitsService.Pensions.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build(),
                     DetailedService.builder()
                         .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
                         .name(HealthService.Covid19Vaccine.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -325,6 +408,21 @@ public class DeserializerTest {
             + "]}",
         CmsOverlay.class,
         overlay);
+    overlay =
+        CmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .build(),
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
+                        .name(HealthService.Covid19Vaccine.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Pensions\",\"appointment_phones\":[]},"
@@ -344,6 +442,23 @@ public class DeserializerTest {
             + "]}",
         CmsOverlay.class,
         overlay);
+    overlay =
+        CmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build(),
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
+                        .name(HealthService.Covid19Vaccine.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Pensions\",\"appointment_phones\":[],\"service_locations\":[]},"
@@ -419,14 +534,10 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(BenefitsService.Pensions.name()))
                         .name(BenefitsService.Pensions.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build(),
                     DetailedService.builder()
                         .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
                         .name(HealthService.Covid19Vaccine.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -448,6 +559,21 @@ public class DeserializerTest {
             + "]}",
         DetailedServicesResponse.class,
         response);
+    response =
+        DetailedServicesResponse.builder()
+            .data(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .build(),
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
+                        .name(HealthService.Covid19Vaccine.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"data\":["
             + "{\"name\":\"Pensions\",\"appointment_phones\":[]},"
@@ -467,6 +593,23 @@ public class DeserializerTest {
             + "]}",
         DetailedServicesResponse.class,
         response);
+    response =
+        DetailedServicesResponse.builder()
+            .data(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build(),
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
+                        .name(HealthService.Covid19Vaccine.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"data\":["
             + "{\"name\":\"Pensions\",\"appointment_phones\":[],\"service_locations\":[]},"
@@ -542,14 +685,10 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(BenefitsService.Pensions.name()))
                         .name(BenefitsService.Pensions.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build(),
                     DetailedService.builder()
                         .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
                         .name(HealthService.Covid19Vaccine.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -571,6 +710,21 @@ public class DeserializerTest {
             + "]}",
         FacilityAttributes.class,
         attributes);
+    attributes =
+        FacilityAttributes.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .build(),
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
+                        .name(HealthService.Covid19Vaccine.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Pensions\",\"appointment_phones\":[]},"
@@ -590,6 +744,23 @@ public class DeserializerTest {
             + "]}",
         FacilityAttributes.class,
         attributes);
+    attributes =
+        FacilityAttributes.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build(),
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
+                        .name(HealthService.Covid19Vaccine.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Pensions\",\"appointment_phones\":[],\"service_locations\":[]},"
@@ -664,14 +835,10 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(BenefitsService.Pensions.name()))
                         .name(BenefitsService.Pensions.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build(),
                     DetailedService.builder()
                         .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
                         .name(HealthService.Covid19Vaccine.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -693,6 +860,21 @@ public class DeserializerTest {
             + "]}",
         Properties.class,
         properties);
+    properties =
+        Properties.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .build(),
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
+                        .name(HealthService.Covid19Vaccine.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Pensions\",\"appointment_phones\":[]},"
@@ -712,6 +894,23 @@ public class DeserializerTest {
             + "]}",
         Properties.class,
         properties);
+    properties =
+        Properties.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build(),
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
+                        .name(HealthService.Covid19Vaccine.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Pensions\",\"appointment_phones\":[],\"service_locations\":[]},"
@@ -744,8 +943,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(HealthService.DentalServices.name()))
                         .name(HealthService.DentalServices.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -758,6 +955,16 @@ public class DeserializerTest {
             + "]}",
         CmsOverlay.class,
         overlay);
+    overlay =
+        CmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.DentalServices.name()))
+                        .name(HealthService.DentalServices.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"DentalServices\",\"appointment_phones\":[]}"
@@ -770,6 +977,17 @@ public class DeserializerTest {
             + "]}",
         CmsOverlay.class,
         overlay);
+    overlay =
+        CmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.DentalServices.name()))
+                        .name(HealthService.DentalServices.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"DentalServices\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -790,8 +1008,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
                         .name(HealthService.Covid19Vaccine.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -804,6 +1020,16 @@ public class DeserializerTest {
             + "]}",
         CmsOverlay.class,
         overlay);
+    overlay =
+        CmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
+                        .name(HealthService.Covid19Vaccine.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Covid19Vaccine\",\"appointment_phones\":[]}"
@@ -816,6 +1042,17 @@ public class DeserializerTest {
             + "]}",
         CmsOverlay.class,
         overlay);
+    overlay =
+        CmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
+                        .name(HealthService.Covid19Vaccine.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Covid19Vaccine\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -837,14 +1074,18 @@ public class DeserializerTest {
         DetailedService.builder()
             .serviceId(uncapitalize(HealthService.DentalServices.name()))
             .name(HealthService.DentalServices.name())
-            .phoneNumbers(emptyList())
-            .serviceLocations(emptyList())
             .build();
     assertJson("{\"name\":\"DentalServices\"}", DetailedService.class, detailedService);
     assertJson(
         "{\"serviceId\":\"dentalServices\",\"name\":\"DentalServices\"}",
         DetailedService.class,
         detailedService);
+    detailedService =
+        DetailedService.builder()
+            .serviceId(uncapitalize(HealthService.DentalServices.name()))
+            .name(HealthService.DentalServices.name())
+            .phoneNumbers(emptyList())
+            .build();
     assertJson(
         "{\"name\":\"DentalServices\",\"appointment_phones\":[]}",
         DetailedService.class,
@@ -853,6 +1094,13 @@ public class DeserializerTest {
         "{\"serviceId\":\"dentalServices\",\"name\":\"DentalServices\",\"appointment_phones\":[]}",
         DetailedService.class,
         detailedService);
+    detailedService =
+        DetailedService.builder()
+            .serviceId(uncapitalize(HealthService.DentalServices.name()))
+            .name(HealthService.DentalServices.name())
+            .phoneNumbers(emptyList())
+            .serviceLocations(emptyList())
+            .build();
     assertJson(
         "{\"name\":\"DentalServices\",\"appointment_phones\":[],\"service_locations\":[]}",
         DetailedService.class,
@@ -874,8 +1122,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(HealthService.DentalServices.name()))
                         .name(HealthService.DentalServices.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -886,6 +1132,16 @@ public class DeserializerTest {
         "{\"data\":[" + "{\"serviceId\":\"dentalServices\",\"name\":\"DentalServices\"}" + "]}",
         DetailedServicesResponse.class,
         response);
+    response =
+        DetailedServicesResponse.builder()
+            .data(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.DentalServices.name()))
+                        .name(HealthService.DentalServices.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"data\":[" + "{\"name\":\"DentalServices\",\"appointment_phones\":[]}" + "]}",
         DetailedServicesResponse.class,
@@ -896,6 +1152,17 @@ public class DeserializerTest {
             + "]}",
         DetailedServicesResponse.class,
         response);
+    response =
+        DetailedServicesResponse.builder()
+            .data(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.DentalServices.name()))
+                        .name(HealthService.DentalServices.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"data\":["
             + "{\"name\":\"DentalServices\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -916,8 +1183,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
                         .name(HealthService.Covid19Vaccine.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -928,6 +1193,16 @@ public class DeserializerTest {
         "{\"data\":[" + "{\"serviceId\":\"covid19Vaccine\",\"name\":\"Covid19Vaccine\"}" + "]}",
         DetailedServicesResponse.class,
         response);
+    response =
+        DetailedServicesResponse.builder()
+            .data(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
+                        .name(HealthService.Covid19Vaccine.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"data\":[" + "{\"name\":\"Covid19Vaccine\",\"appointment_phones\":[]}" + "]}",
         DetailedServicesResponse.class,
@@ -938,6 +1213,17 @@ public class DeserializerTest {
             + "]}",
         DetailedServicesResponse.class,
         response);
+    response =
+        DetailedServicesResponse.builder()
+            .data(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
+                        .name(HealthService.Covid19Vaccine.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"data\":["
             + "{\"name\":\"Covid19Vaccine\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -963,8 +1249,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(HealthService.DentalServices.name()))
                         .name(HealthService.DentalServices.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -977,6 +1261,16 @@ public class DeserializerTest {
             + "]}",
         FacilityAttributes.class,
         attributes);
+    attributes =
+        FacilityAttributes.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.DentalServices.name()))
+                        .name(HealthService.DentalServices.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"DentalServices\",\"appointment_phones\":[]}"
@@ -989,6 +1283,17 @@ public class DeserializerTest {
             + "]}",
         FacilityAttributes.class,
         attributes);
+    attributes =
+        FacilityAttributes.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.DentalServices.name()))
+                        .name(HealthService.DentalServices.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"DentalServices\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -1009,8 +1314,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
                         .name(HealthService.Covid19Vaccine.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -1023,6 +1326,16 @@ public class DeserializerTest {
             + "]}",
         FacilityAttributes.class,
         attributes);
+    attributes =
+        FacilityAttributes.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
+                        .name(HealthService.Covid19Vaccine.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Covid19Vaccine\",\"appointment_phones\":[]}"
@@ -1035,6 +1348,17 @@ public class DeserializerTest {
             + "]}",
         FacilityAttributes.class,
         attributes);
+    attributes =
+        FacilityAttributes.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
+                        .name(HealthService.Covid19Vaccine.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Covid19Vaccine\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -1060,8 +1384,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(HealthService.DentalServices.name()))
                         .name(HealthService.DentalServices.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -1074,6 +1396,16 @@ public class DeserializerTest {
             + "]}",
         Properties.class,
         properties);
+    properties =
+        Properties.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.DentalServices.name()))
+                        .name(HealthService.DentalServices.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"DentalServices\",\"appointment_phones\":[]}"
@@ -1086,6 +1418,17 @@ public class DeserializerTest {
             + "]}",
         Properties.class,
         properties);
+    properties =
+        Properties.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.DentalServices.name()))
+                        .name(HealthService.DentalServices.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"DentalServices\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -1106,8 +1449,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
                         .name(HealthService.Covid19Vaccine.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -1120,6 +1461,16 @@ public class DeserializerTest {
             + "]}",
         Properties.class,
         properties);
+    properties =
+        Properties.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
+                        .name(HealthService.Covid19Vaccine.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Covid19Vaccine\",\"appointment_phones\":[]}"
@@ -1132,6 +1483,17 @@ public class DeserializerTest {
             + "]}",
         Properties.class,
         properties);
+    properties =
+        Properties.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Covid19Vaccine.name()))
+                        .name(HealthService.Covid19Vaccine.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Covid19Vaccine\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -1150,12 +1512,7 @@ public class DeserializerTest {
   @SneakyThrows
   void deserializeInvalidDetailedService() {
     DetailedService invalidService =
-        DetailedService.builder()
-            .serviceId(INVALID_SVC_ID)
-            .name("foo")
-            .phoneNumbers(emptyList())
-            .serviceLocations(emptyList())
-            .build();
+        DetailedService.builder().serviceId(INVALID_SVC_ID).name("foo").build();
     assertJson("{\"name\":\"foo\"}", DetailedService.class, invalidService);
     invalidService.name("OnlineScheduling");
     assertJson(
@@ -1185,8 +1542,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
                         .name(OtherService.OnlineScheduling.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -1199,6 +1554,16 @@ public class DeserializerTest {
             + "]}",
         CmsOverlay.class,
         overlay);
+    overlay =
+        CmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+                        .name(OtherService.OnlineScheduling.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"OnlineScheduling\",\"appointment_phones\":[]}"
@@ -1211,6 +1576,17 @@ public class DeserializerTest {
             + "]}",
         CmsOverlay.class,
         overlay);
+    overlay =
+        CmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+                        .name(OtherService.OnlineScheduling.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"OnlineScheduling\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -1232,14 +1608,18 @@ public class DeserializerTest {
         DetailedService.builder()
             .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
             .name(OtherService.OnlineScheduling.name())
-            .phoneNumbers(emptyList())
-            .serviceLocations(emptyList())
             .build();
     assertJson("{\"name\":\"OnlineScheduling\"}", DetailedService.class, detailedService);
     assertJson(
         "{\"serviceId\":\"onlineScheduling\",\"name\":\"OnlineScheduling\"}",
         DetailedService.class,
         detailedService);
+    detailedService =
+        DetailedService.builder()
+            .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+            .name(OtherService.OnlineScheduling.name())
+            .phoneNumbers(emptyList())
+            .build();
     assertJson(
         "{\"name\":\"OnlineScheduling\",\"appointment_phones\":[]}",
         DetailedService.class,
@@ -1248,6 +1628,13 @@ public class DeserializerTest {
         "{\"serviceId\":\"onlineScheduling\",\"name\":\"OnlineScheduling\",\"appointment_phones\":[]}",
         DetailedService.class,
         detailedService);
+    detailedService =
+        DetailedService.builder()
+            .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+            .name(OtherService.OnlineScheduling.name())
+            .phoneNumbers(emptyList())
+            .serviceLocations(emptyList())
+            .build();
     assertJson(
         "{\"name\":\"OnlineScheduling\",\"appointment_phones\":[],\"service_locations\":[]}",
         DetailedService.class,
@@ -1269,8 +1656,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
                         .name(OtherService.OnlineScheduling.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -1281,6 +1666,16 @@ public class DeserializerTest {
         "{\"data\":[" + "{\"serviceId\":\"onlineScheduling\",\"name\":\"OnlineScheduling\"}" + "]}",
         DetailedServicesResponse.class,
         response);
+    response =
+        DetailedServicesResponse.builder()
+            .data(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+                        .name(OtherService.OnlineScheduling.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"data\":[" + "{\"name\":\"OnlineScheduling\",\"appointment_phones\":[]}" + "]}",
         DetailedServicesResponse.class,
@@ -1291,6 +1686,17 @@ public class DeserializerTest {
             + "]}",
         DetailedServicesResponse.class,
         response);
+    response =
+        DetailedServicesResponse.builder()
+            .data(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+                        .name(OtherService.OnlineScheduling.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"data\":["
             + "{\"name\":\"OnlineScheduling\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -1316,8 +1722,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
                         .name(OtherService.OnlineScheduling.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -1330,6 +1734,16 @@ public class DeserializerTest {
             + "]}",
         FacilityAttributes.class,
         attributes);
+    attributes =
+        FacilityAttributes.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+                        .name(OtherService.OnlineScheduling.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"OnlineScheduling\",\"appointment_phones\":[]}"
@@ -1342,6 +1756,17 @@ public class DeserializerTest {
             + "]}",
         FacilityAttributes.class,
         attributes);
+    attributes =
+        FacilityAttributes.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+                        .name(OtherService.OnlineScheduling.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"OnlineScheduling\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -1367,8 +1792,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
                         .name(OtherService.OnlineScheduling.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -1381,6 +1804,16 @@ public class DeserializerTest {
             + "]}",
         Properties.class,
         properties);
+    properties =
+        Properties.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+                        .name(OtherService.OnlineScheduling.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"OnlineScheduling\",\"appointment_phones\":[]}"
@@ -1393,6 +1826,17 @@ public class DeserializerTest {
             + "]}",
         Properties.class,
         properties);
+    properties =
+        Properties.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+                        .name(OtherService.OnlineScheduling.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"OnlineScheduling\",\"appointment_phones\":[],\"service_locations\":[]}"

--- a/facilities-api/src/test/java/gov/va/api/lighthouse/facilities/api/v1/deserializers/DeserializerTest.java
+++ b/facilities-api/src/test/java/gov/va/api/lighthouse/facilities/api/v1/deserializers/DeserializerTest.java
@@ -34,8 +34,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(BenefitsService.Pensions.name()))
                         .name(BenefitsService.Pensions.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -44,6 +42,16 @@ public class DeserializerTest {
         "{\"detailedServices\":[" + "{\"serviceId\":\"pensions\",\"name\":\"Pensions\"}" + "]}",
         CmsOverlay.class,
         overlay);
+    overlay =
+        CmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailedServices\":[" + "{\"name\":\"Pensions\",\"appointmentPhones\":[]}" + "]}",
         CmsOverlay.class,
@@ -54,6 +62,17 @@ public class DeserializerTest {
             + "]}",
         CmsOverlay.class,
         overlay);
+    overlay =
+        CmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailedServices\":["
             + "{\"name\":\"Pensions\",\"appointmentPhones\":[],\"serviceLocations\":[]}"
@@ -75,20 +94,31 @@ public class DeserializerTest {
         DetailedService.builder()
             .serviceId(uncapitalize(BenefitsService.Pensions.name()))
             .name(BenefitsService.Pensions.name())
-            .phoneNumbers(emptyList())
-            .serviceLocations(emptyList())
             .build();
     assertJson("{\"name\":\"Pensions\"}", DetailedService.class, detailedService);
     assertJson(
         "{\"serviceId\":\"pensions\",\"name\":\"Pensions\"}",
         DetailedService.class,
         detailedService);
+    detailedService =
+        DetailedService.builder()
+            .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+            .name(BenefitsService.Pensions.name())
+            .phoneNumbers(emptyList())
+            .build();
     assertJson(
         "{\"name\":\"Pensions\",\"appointmentPhones\":[]}", DetailedService.class, detailedService);
     assertJson(
         "{\"serviceId\":\"pensions\",\"name\":\"Pensions\",\"appointmentPhones\":[]}",
         DetailedService.class,
         detailedService);
+    detailedService =
+        DetailedService.builder()
+            .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+            .name(BenefitsService.Pensions.name())
+            .phoneNumbers(emptyList())
+            .serviceLocations(emptyList())
+            .build();
     assertJson(
         "{\"name\":\"Pensions\",\"appointmentPhones\":[],\"serviceLocations\":[]}",
         DetailedService.class,
@@ -109,8 +139,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(BenefitsService.Pensions.name()))
                         .name(BenefitsService.Pensions.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -119,6 +147,16 @@ public class DeserializerTest {
         "{\"data\":[" + "{\"serviceId\":\"pensions\",\"name\":\"Pensions\"}" + "]}",
         DetailedServicesResponse.class,
         response);
+    response =
+        DetailedServicesResponse.builder()
+            .data(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"data\":[" + "{\"name\":\"Pensions\",\"appointmentPhones\":[]}" + "]}",
         DetailedServicesResponse.class,
@@ -129,6 +167,17 @@ public class DeserializerTest {
             + "]}",
         DetailedServicesResponse.class,
         response);
+    response =
+        DetailedServicesResponse.builder()
+            .data(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"data\":["
             + "{\"name\":\"Pensions\",\"appointmentPhones\":[],\"serviceLocations\":[]}"
@@ -195,14 +244,10 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(BenefitsService.Pensions.name()))
                         .name(BenefitsService.Pensions.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build(),
                     DetailedService.builder()
                         .serviceId(uncapitalize(HealthService.Smoking.name()))
                         .name(HealthService.Smoking.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -222,6 +267,21 @@ public class DeserializerTest {
             + "]}",
         CmsOverlay.class,
         overlay);
+    overlay =
+        CmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .build(),
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Smoking.name()))
+                        .name(HealthService.Smoking.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailedServices\":["
             + "{\"name\":\"Pensions\",\"appointmentPhones\":[]},"
@@ -239,6 +299,23 @@ public class DeserializerTest {
             + "]}",
         CmsOverlay.class,
         overlay);
+    overlay =
+        CmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build(),
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Smoking.name()))
+                        .name(HealthService.Smoking.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailedServices\":["
             + "{\"name\":\"Pensions\",\"appointmentPhones\":[],\"serviceLocations\":[]},"
@@ -311,14 +388,10 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(BenefitsService.Pensions.name()))
                         .name(BenefitsService.Pensions.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build(),
                     DetailedService.builder()
                         .serviceId(uncapitalize(HealthService.Smoking.name()))
                         .name(HealthService.Smoking.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -338,6 +411,21 @@ public class DeserializerTest {
             + "]}",
         DetailedServicesResponse.class,
         response);
+    response =
+        DetailedServicesResponse.builder()
+            .data(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .build(),
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Smoking.name()))
+                        .name(HealthService.Smoking.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"data\":["
             + "{\"name\":\"Pensions\",\"appointmentPhones\":[]},"
@@ -355,6 +443,23 @@ public class DeserializerTest {
             + "]}",
         DetailedServicesResponse.class,
         response);
+    response =
+        DetailedServicesResponse.builder()
+            .data(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build(),
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Smoking.name()))
+                        .name(HealthService.Smoking.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"data\":["
             + "{\"name\":\"Pensions\",\"appointmentPhones\":[],\"serviceLocations\":[]},"
@@ -384,8 +489,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(HealthService.Dental.name()))
                         .name(HealthService.Dental.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -394,6 +497,16 @@ public class DeserializerTest {
         "{\"detailedServices\":[" + "{\"serviceId\":\"dental\",\"name\":\"Dental\"}" + "]}",
         CmsOverlay.class,
         overlay);
+    overlay =
+        CmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Dental.name()))
+                        .name(HealthService.Dental.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailedServices\":[" + "{\"name\":\"Dental\",\"appointmentPhones\":[]}" + "]}",
         CmsOverlay.class,
@@ -404,6 +517,17 @@ public class DeserializerTest {
             + "]}",
         CmsOverlay.class,
         overlay);
+    overlay =
+        CmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Dental.name()))
+                        .name(HealthService.Dental.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailedServices\":["
             + "{\"name\":\"Dental\",\"appointmentPhones\":[],\"serviceLocations\":[]}"
@@ -425,18 +549,29 @@ public class DeserializerTest {
         DetailedService.builder()
             .serviceId(uncapitalize(HealthService.Dental.name()))
             .name(HealthService.Dental.name())
-            .phoneNumbers(emptyList())
-            .serviceLocations(emptyList())
             .build();
     assertJson("{\"name\":\"Dental\"}", DetailedService.class, detailedService);
     assertJson(
         "{\"serviceId\":\"dental\",\"name\":\"Dental\"}", DetailedService.class, detailedService);
+    detailedService =
+        DetailedService.builder()
+            .serviceId(uncapitalize(HealthService.Dental.name()))
+            .name(HealthService.Dental.name())
+            .phoneNumbers(emptyList())
+            .build();
     assertJson(
         "{\"name\":\"Dental\",\"appointmentPhones\":[]}", DetailedService.class, detailedService);
     assertJson(
         "{\"serviceId\":\"dental\",\"name\":\"Dental\",\"appointmentPhones\":[]}",
         DetailedService.class,
         detailedService);
+    detailedService =
+        DetailedService.builder()
+            .serviceId(uncapitalize(HealthService.Dental.name()))
+            .name(HealthService.Dental.name())
+            .phoneNumbers(emptyList())
+            .serviceLocations(emptyList())
+            .build();
     assertJson(
         "{\"name\":\"Dental\",\"appointmentPhones\":[],\"serviceLocations\":[]}",
         DetailedService.class,
@@ -457,8 +592,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(HealthService.Dental.name()))
                         .name(HealthService.Dental.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -467,6 +600,16 @@ public class DeserializerTest {
         "{\"data\":[" + "{\"serviceId\":\"dental\",\"name\":\"Dental\"}" + "]}",
         DetailedServicesResponse.class,
         response);
+    response =
+        DetailedServicesResponse.builder()
+            .data(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Dental.name()))
+                        .name(HealthService.Dental.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"data\":[" + "{\"name\":\"Dental\",\"appointmentPhones\":[]}" + "]}",
         DetailedServicesResponse.class,
@@ -477,6 +620,17 @@ public class DeserializerTest {
             + "]}",
         DetailedServicesResponse.class,
         response);
+    response =
+        DetailedServicesResponse.builder()
+            .data(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Dental.name()))
+                        .name(HealthService.Dental.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"data\":["
             + "{\"name\":\"Dental\",\"appointmentPhones\":[],\"serviceLocations\":[]}"
@@ -495,12 +649,7 @@ public class DeserializerTest {
   @SneakyThrows
   void deserializeInvalidDetailedService() {
     DetailedService invalidService =
-        DetailedService.builder()
-            .serviceId(INVALID_SVC_ID)
-            .name("foo")
-            .phoneNumbers(emptyList())
-            .serviceLocations(emptyList())
-            .build();
+        DetailedService.builder().serviceId(INVALID_SVC_ID).name("foo").build();
     assertJson("{\"name\":\"foo\"}", DetailedService.class, invalidService);
     invalidService.name("OnlineScheduling");
     assertJson(
@@ -524,8 +673,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
                         .name(OtherService.OnlineScheduling.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -538,6 +685,16 @@ public class DeserializerTest {
             + "]}",
         CmsOverlay.class,
         overlay);
+    overlay =
+        CmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+                        .name(OtherService.OnlineScheduling.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailedServices\":["
             + "{\"name\":\"OnlineScheduling\",\"appointmentPhones\":[]}"
@@ -550,6 +707,17 @@ public class DeserializerTest {
             + "]}",
         CmsOverlay.class,
         overlay);
+    overlay =
+        CmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+                        .name(OtherService.OnlineScheduling.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailedServices\":["
             + "{\"name\":\"OnlineScheduling\",\"appointmentPhones\":[],\"serviceLocations\":[]}"
@@ -571,14 +739,18 @@ public class DeserializerTest {
         DetailedService.builder()
             .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
             .name(OtherService.OnlineScheduling.name())
-            .phoneNumbers(emptyList())
-            .serviceLocations(emptyList())
             .build();
     assertJson("{\"name\":\"OnlineScheduling\"}", DetailedService.class, detailedService);
     assertJson(
         "{\"serviceId\":\"onlineScheduling\",\"name\":\"OnlineScheduling\"}",
         DetailedService.class,
         detailedService);
+    detailedService =
+        DetailedService.builder()
+            .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+            .name(OtherService.OnlineScheduling.name())
+            .phoneNumbers(emptyList())
+            .build();
     assertJson(
         "{\"name\":\"OnlineScheduling\",\"appointmentPhones\":[]}",
         DetailedService.class,
@@ -587,6 +759,13 @@ public class DeserializerTest {
         "{\"serviceId\":\"onlineScheduling\",\"name\":\"OnlineScheduling\",\"appointmentPhones\":[]}",
         DetailedService.class,
         detailedService);
+    detailedService =
+        DetailedService.builder()
+            .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+            .name(OtherService.OnlineScheduling.name())
+            .phoneNumbers(emptyList())
+            .serviceLocations(emptyList())
+            .build();
     assertJson(
         "{\"name\":\"OnlineScheduling\",\"appointmentPhones\":[],\"serviceLocations\":[]}",
         DetailedService.class,
@@ -607,8 +786,6 @@ public class DeserializerTest {
                     DetailedService.builder()
                         .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
                         .name(OtherService.OnlineScheduling.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -619,6 +796,16 @@ public class DeserializerTest {
         "{\"data\":[" + "{\"serviceId\":\"onlineScheduling\",\"name\":\"OnlineScheduling\"}" + "]}",
         DetailedServicesResponse.class,
         response);
+    response =
+        DetailedServicesResponse.builder()
+            .data(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+                        .name(OtherService.OnlineScheduling.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"data\":[" + "{\"name\":\"OnlineScheduling\",\"appointmentPhones\":[]}" + "]}",
         DetailedServicesResponse.class,
@@ -629,6 +816,17 @@ public class DeserializerTest {
             + "]}",
         DetailedServicesResponse.class,
         response);
+    response =
+        DetailedServicesResponse.builder()
+            .data(
+                List.of(
+                    DetailedService.builder()
+                        .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+                        .name(OtherService.OnlineScheduling.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"data\":["
             + "{\"name\":\"OnlineScheduling\",\"appointmentPhones\":[],\"serviceLocations\":[]}"

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/BaseVersionedTransformer.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/BaseVersionedTransformer.java
@@ -18,14 +18,6 @@ abstract class BaseVersionedTransformer {
             gov.va.api.lighthouse.facilities.api.v0.Facility.HealthService.DentalServices);
   }
 
-  protected static boolean checkHealthServiceNameChange(
-      @NonNull gov.va.api.lighthouse.facilities.api.v1.Facility.HealthService healthService) {
-    return healthService.equals(
-            gov.va.api.lighthouse.facilities.api.v1.Facility.HealthService.MentalHealth)
-        || healthService.equals(
-            gov.va.api.lighthouse.facilities.api.v1.Facility.HealthService.Dental);
-  }
-
   protected static boolean containsValueOfName(@NonNull Enum<?>[] values, @NonNull String name) {
     return Arrays.stream(values).parallel().anyMatch(e -> e.name().equals(name));
   }

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/DatamartFacility.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/DatamartFacility.java
@@ -62,7 +62,15 @@ public class DatamartFacility {
     TransitionAssistance,
     UpdatingDirectDepositInformation,
     VAHomeLoanAssistance,
-    VocationalRehabilitationAndEmploymentAssistance
+    VocationalRehabilitationAndEmploymentAssistance;
+
+    /** Ensure that Jackson can create BenefitsService enum regardless of capitalization. */
+    @JsonCreator
+    public static BenefitsService fromString(String name) {
+      return eBenefitsRegistrationAssistance.name().equalsIgnoreCase(name)
+          ? eBenefitsRegistrationAssistance
+          : valueOf(capitalize(name));
+    }
   }
 
   public enum FacilityType {
@@ -284,12 +292,10 @@ public class DatamartFacility {
     @JsonCreator
     public static HealthService fromString(String name) {
       return "COVID-19 vaccines".equalsIgnoreCase(name)
-          ? HealthService.Covid19Vaccine
+          ? Covid19Vaccine
           : "MentalHealthCare".equalsIgnoreCase(name)
-              ? HealthService.MentalHealth
-              : "DentalServices".equalsIgnoreCase(name)
-                  ? HealthService.Dental
-                  : valueOf(capitalize(name));
+              ? MentalHealth
+              : "DentalServices".equalsIgnoreCase(name) ? Dental : valueOf(capitalize(name));
     }
   }
 

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/FacilityTransformerV0.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/FacilityTransformerV0.java
@@ -194,7 +194,7 @@ public final class FacilityTransformerV0 extends BaseVersionedTransformer {
       @NonNull DatamartFacility.BenefitsService datamartFacilityBenefitsService) {
     return containsValueOfName(
             Facility.BenefitsService.values(), datamartFacilityBenefitsService.name())
-        ? Facility.BenefitsService.valueOf(datamartFacilityBenefitsService.name())
+        ? Facility.BenefitsService.fromString(datamartFacilityBenefitsService.name())
         : null;
   }
 
@@ -203,7 +203,7 @@ public final class FacilityTransformerV0 extends BaseVersionedTransformer {
       @NonNull Facility.BenefitsService facilityBenefitsService) {
     return containsValueOfName(
             DatamartFacility.BenefitsService.values(), facilityBenefitsService.name())
-        ? DatamartFacility.BenefitsService.valueOf(facilityBenefitsService.name())
+        ? DatamartFacility.BenefitsService.fromString(facilityBenefitsService.name())
         : null;
   }
 

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/FacilityTransformerV0.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/FacilityTransformerV0.java
@@ -50,12 +50,8 @@ public final class FacilityTransformerV0 extends BaseVersionedTransformer {
         ? Facility.OperatingStatus.builder()
             .code(
                 (datamartFacilityOperatingStatus.code() != null)
-                    ? containsValueOfName(
-                            Facility.OperatingStatusCode.values(),
-                            datamartFacilityOperatingStatus.code().name())
-                        ? Facility.OperatingStatusCode.valueOf(
-                            datamartFacilityOperatingStatus.code().name())
-                        : null
+                    ? Facility.OperatingStatusCode.valueOf(
+                        datamartFacilityOperatingStatus.code().name())
                     : null)
             .additionalInfo(datamartFacilityOperatingStatus.additionalInfo())
             .build()
@@ -105,12 +101,8 @@ public final class FacilityTransformerV0 extends BaseVersionedTransformer {
         ? DatamartFacility.OperatingStatus.builder()
             .code(
                 (facilityOperatingStatus.code() != null)
-                    ? containsValueOfName(
-                            DatamartFacility.OperatingStatusCode.values(),
-                            facilityOperatingStatus.code().name())
-                        ? DatamartFacility.OperatingStatusCode.valueOf(
-                            facilityOperatingStatus.code().name())
-                        : null
+                    ? DatamartFacility.OperatingStatusCode.valueOf(
+                        facilityOperatingStatus.code().name())
                     : null)
             .additionalInfo(facilityOperatingStatus.additionalInfo())
             .build()
@@ -121,9 +113,7 @@ public final class FacilityTransformerV0 extends BaseVersionedTransformer {
   private static Facility.ActiveStatus transformFacilityActiveStatus(
       DatamartFacility.ActiveStatus datamartFacilityActiveStatus) {
     return (datamartFacilityActiveStatus != null)
-        ? containsValueOfName(Facility.ActiveStatus.values(), datamartFacilityActiveStatus.name())
-            ? Facility.ActiveStatus.valueOf(datamartFacilityActiveStatus.name())
-            : null
+        ? Facility.ActiveStatus.valueOf(datamartFacilityActiveStatus.name())
         : null;
   }
 
@@ -131,9 +121,7 @@ public final class FacilityTransformerV0 extends BaseVersionedTransformer {
   private static DatamartFacility.ActiveStatus transformFacilityActiveStatus(
       Facility.ActiveStatus facilityActiveStatus) {
     return (facilityActiveStatus != null)
-        ? containsValueOfName(DatamartFacility.ActiveStatus.values(), facilityActiveStatus.name())
-            ? DatamartFacility.ActiveStatus.valueOf(facilityActiveStatus.name())
-            : null
+        ? DatamartFacility.ActiveStatus.valueOf(facilityActiveStatus.name())
         : null;
   }
 
@@ -192,19 +180,13 @@ public final class FacilityTransformerV0 extends BaseVersionedTransformer {
   /** Transform DatamartFacility benefits service to version 0 facility benefits service. */
   private static Facility.BenefitsService transformFacilityBenefitsService(
       @NonNull DatamartFacility.BenefitsService datamartFacilityBenefitsService) {
-    return containsValueOfName(
-            Facility.BenefitsService.values(), datamartFacilityBenefitsService.name())
-        ? Facility.BenefitsService.fromString(datamartFacilityBenefitsService.name())
-        : null;
+    return Facility.BenefitsService.fromString(datamartFacilityBenefitsService.name());
   }
 
   /** Transform version 0 facility benefits service to DatamartFacility benefits service. */
   private static DatamartFacility.BenefitsService transformFacilityBenefitsService(
       @NonNull Facility.BenefitsService facilityBenefitsService) {
-    return containsValueOfName(
-            DatamartFacility.BenefitsService.values(), facilityBenefitsService.name())
-        ? DatamartFacility.BenefitsService.fromString(facilityBenefitsService.name())
-        : null;
+    return DatamartFacility.BenefitsService.fromString(facilityBenefitsService.name());
   }
 
   /** Transform DatamartFacility health service to version 0 facility health service. */
@@ -214,10 +196,7 @@ public final class FacilityTransformerV0 extends BaseVersionedTransformer {
         ? Facility.HealthService.MentalHealthCare
         : datamartFacilityHealthService.equals(DatamartFacility.HealthService.Dental)
             ? Facility.HealthService.DentalServices
-            : containsValueOfName(
-                    Facility.HealthService.values(), datamartFacilityHealthService.name())
-                ? Facility.HealthService.valueOf(datamartFacilityHealthService.name())
-                : null;
+            : Facility.HealthService.valueOf(datamartFacilityHealthService.name());
   }
 
   /** Transform version 0 facility health service to DatamartFacility health service. */
@@ -227,10 +206,7 @@ public final class FacilityTransformerV0 extends BaseVersionedTransformer {
         ? DatamartFacility.HealthService.MentalHealth
         : facilityHealthService.equals(Facility.HealthService.DentalServices)
             ? DatamartFacility.HealthService.Dental
-            : containsValueOfName(
-                    DatamartFacility.HealthService.values(), facilityHealthService.name())
-                ? DatamartFacility.HealthService.valueOf(facilityHealthService.name())
-                : null;
+            : DatamartFacility.HealthService.valueOf(facilityHealthService.name());
   }
 
   /** Transform DatamartFacility hours to version 0 facility hours. */
@@ -267,17 +243,13 @@ public final class FacilityTransformerV0 extends BaseVersionedTransformer {
   /** Transform DatamartFacility other service to version 0 facility other service. */
   private static Facility.OtherService transformFacilityOtherService(
       @NonNull DatamartFacility.OtherService datamartFacilityOtherService) {
-    return containsValueOfName(Facility.OtherService.values(), datamartFacilityOtherService.name())
-        ? Facility.OtherService.valueOf(datamartFacilityOtherService.name())
-        : null;
+    return Facility.OtherService.valueOf(datamartFacilityOtherService.name());
   }
 
   /** Transform version 0 facility other service to DatamartFacility other service. */
   private static DatamartFacility.OtherService transformFacilityOtherService(
       @NonNull Facility.OtherService facilityOtherService) {
-    return containsValueOfName(DatamartFacility.OtherService.values(), facilityOtherService.name())
-        ? DatamartFacility.OtherService.valueOf(facilityOtherService.name())
-        : null;
+    return DatamartFacility.OtherService.valueOf(facilityOtherService.name());
   }
 
   /** Transform DatamartFacility patient wait times to version 0 facility patient wait times. */
@@ -397,15 +369,12 @@ public final class FacilityTransformerV0 extends BaseVersionedTransformer {
             .benefits(
                 (datamartFacilityServices.benefits() != null)
                     ? datamartFacilityServices.benefits().parallelStream()
-                        .filter(
-                            e -> containsValueOfName(Facility.BenefitsService.values(), e.name()))
                         .map(e -> transformFacilityBenefitsService(e))
                         .collect(Collectors.toList())
                     : null)
             .other(
                 (datamartFacilityServices.other() != null)
                     ? datamartFacilityServices.other().parallelStream()
-                        .filter(e -> containsValueOfName(Facility.OtherService.values(), e.name()))
                         .map(e -> transformFacilityOtherService(e))
                         .collect(Collectors.toList())
                     : null)
@@ -433,20 +402,12 @@ public final class FacilityTransformerV0 extends BaseVersionedTransformer {
             .benefits(
                 (facilityServices.benefits() != null)
                     ? facilityServices.benefits().parallelStream()
-                        .filter(
-                            e ->
-                                containsValueOfName(
-                                    DatamartFacility.BenefitsService.values(), e.name()))
                         .map(e -> transformFacilityBenefitsService(e))
                         .collect(Collectors.toList())
                     : null)
             .other(
                 (facilityServices.other() != null)
                     ? facilityServices.other().parallelStream()
-                        .filter(
-                            e ->
-                                containsValueOfName(
-                                    DatamartFacility.OtherService.values(), e.name()))
                         .map(e -> transformFacilityOtherService(e))
                         .collect(Collectors.toList())
                     : null)
@@ -459,9 +420,7 @@ public final class FacilityTransformerV0 extends BaseVersionedTransformer {
   private static Facility.FacilityType transformFacilityType(
       DatamartFacility.FacilityType datamartFacilityType) {
     return (datamartFacilityType != null)
-        ? containsValueOfName(Facility.FacilityType.values(), datamartFacilityType.name())
-            ? Facility.FacilityType.valueOf(datamartFacilityType.name())
-            : null
+        ? Facility.FacilityType.valueOf(datamartFacilityType.name())
         : null;
   }
 
@@ -469,9 +428,7 @@ public final class FacilityTransformerV0 extends BaseVersionedTransformer {
   private static DatamartFacility.FacilityType transformFacilityType(
       Facility.FacilityType facilityType) {
     return (facilityType != null)
-        ? containsValueOfName(DatamartFacility.FacilityType.values(), facilityType.name())
-            ? DatamartFacility.FacilityType.valueOf(facilityType.name())
-            : null
+        ? DatamartFacility.FacilityType.valueOf(facilityType.name())
         : null;
   }
 
@@ -509,19 +466,11 @@ public final class FacilityTransformerV0 extends BaseVersionedTransformer {
 
   /** Transform version 0 facility type to DatamartFacility facility type. */
   private static Facility.Type transformType(DatamartFacility.Type datamartType) {
-    return (datamartType != null)
-        ? containsValueOfName(Facility.Type.values(), datamartType.name())
-            ? Facility.Type.valueOf(datamartType.name())
-            : null
-        : null;
+    return (datamartType != null) ? Facility.Type.valueOf(datamartType.name()) : null;
   }
 
   /** Transform DatamartFacility type to version 0 facility type. */
   private static DatamartFacility.Type transformType(Facility.Type type) {
-    return (type != null)
-        ? containsValueOfName(DatamartFacility.Type.values(), type.name())
-            ? DatamartFacility.Type.valueOf(type.name())
-            : null
-        : null;
+    return (type != null) ? DatamartFacility.Type.valueOf(type.name()) : null;
   }
 }

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/FacilityTransformerV1.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/FacilityTransformerV1.java
@@ -61,12 +61,8 @@ public final class FacilityTransformerV1 extends BaseVersionedTransformer {
         ? Facility.OperatingStatus.builder()
             .code(
                 (datamartFacilityOperatingStatus.code() != null)
-                    ? containsValueOfName(
-                            Facility.OperatingStatusCode.values(),
-                            datamartFacilityOperatingStatus.code().name())
-                        ? Facility.OperatingStatusCode.valueOf(
-                            datamartFacilityOperatingStatus.code().name())
-                        : null
+                    ? Facility.OperatingStatusCode.valueOf(
+                        datamartFacilityOperatingStatus.code().name())
                     : null)
             .additionalInfo(datamartFacilityOperatingStatus.additionalInfo())
             .build()
@@ -80,12 +76,8 @@ public final class FacilityTransformerV1 extends BaseVersionedTransformer {
         ? Facility.OperatingStatus.builder()
             .code(
                 (datamartFacilityOperatingStatus.code() != null)
-                    ? containsValueOfName(
-                            Facility.OperatingStatusCode.values(),
-                            datamartFacilityOperatingStatus.code().name())
-                        ? Facility.OperatingStatusCode.valueOf(
-                            datamartFacilityOperatingStatus.code().name())
-                        : null
+                    ? Facility.OperatingStatusCode.valueOf(
+                        datamartFacilityOperatingStatus.code().name())
                     : null)
             .additionalInfo(datamartFacilityOperatingStatus.additionalInfo())
             .build()
@@ -132,12 +124,8 @@ public final class FacilityTransformerV1 extends BaseVersionedTransformer {
         ? DatamartFacility.OperatingStatus.builder()
             .code(
                 (facilityOperatingStatus.code() != null)
-                    ? containsValueOfName(
-                            DatamartFacility.OperatingStatusCode.values(),
-                            facilityOperatingStatus.code().name())
-                        ? DatamartFacility.OperatingStatusCode.valueOf(
-                            facilityOperatingStatus.code().name())
-                        : null
+                    ? DatamartFacility.OperatingStatusCode.valueOf(
+                        facilityOperatingStatus.code().name())
                     : null)
             .additionalInfo(facilityOperatingStatus.additionalInfo())
             .build()
@@ -212,19 +200,13 @@ public final class FacilityTransformerV1 extends BaseVersionedTransformer {
   /** Transform DatamartFacility benefits service to version 1 facility benefits service. */
   private static Facility.BenefitsService transformFacilityBenefitsService(
       @NonNull DatamartFacility.BenefitsService datamartFacilityBenefitsService) {
-    return containsValueOfName(
-            Facility.BenefitsService.values(), datamartFacilityBenefitsService.name())
-        ? Facility.BenefitsService.fromString(datamartFacilityBenefitsService.name())
-        : null;
+    return Facility.BenefitsService.fromString(datamartFacilityBenefitsService.name());
   }
 
   /** Transform version 1 facility benefits service to DatamartFacility benefits service. */
   private static DatamartFacility.BenefitsService transformFacilityBenefitsService(
       @NonNull Facility.BenefitsService facilityBenefitsService) {
-    return containsValueOfName(
-            DatamartFacility.BenefitsService.values(), facilityBenefitsService.name())
-        ? DatamartFacility.BenefitsService.fromString(facilityBenefitsService.name())
-        : null;
+    return DatamartFacility.BenefitsService.fromString(facilityBenefitsService.name());
   }
 
   /** Transform DatamartFacility health service to version 1 facility health service. */
@@ -234,10 +216,7 @@ public final class FacilityTransformerV1 extends BaseVersionedTransformer {
         ? Facility.HealthService.MentalHealth
         : datamartFacilityHealthService.equals(DatamartFacility.HealthService.DentalServices)
             ? Facility.HealthService.Dental
-            : containsValueOfName(
-                    Facility.HealthService.values(), datamartFacilityHealthService.name())
-                ? Facility.HealthService.valueOf(datamartFacilityHealthService.name())
-                : null;
+            : Facility.HealthService.valueOf(datamartFacilityHealthService.name());
   }
 
   /** Transform version 1 facility health service to DatamartFacility health service. */
@@ -247,10 +226,7 @@ public final class FacilityTransformerV1 extends BaseVersionedTransformer {
         ? DatamartFacility.HealthService.MentalHealth
         : facilityHealthService.equals(Facility.HealthService.Dental)
             ? DatamartFacility.HealthService.Dental
-            : containsValueOfName(
-                    DatamartFacility.HealthService.values(), facilityHealthService.name())
-                ? DatamartFacility.HealthService.valueOf(facilityHealthService.name())
-                : null;
+            : DatamartFacility.HealthService.valueOf(facilityHealthService.name());
   }
 
   /** Transform DatamartFacility hours to version 1 facility hours. */
@@ -287,17 +263,13 @@ public final class FacilityTransformerV1 extends BaseVersionedTransformer {
   /** Transform DatamartFacility other service to version 1 facility other service. */
   private static Facility.OtherService transformFacilityOtherService(
       @NonNull DatamartFacility.OtherService datamartFacilityOtherService) {
-    return containsValueOfName(Facility.OtherService.values(), datamartFacilityOtherService.name())
-        ? Facility.OtherService.valueOf(datamartFacilityOtherService.name())
-        : null;
+    return Facility.OtherService.valueOf(datamartFacilityOtherService.name());
   }
 
   /** Transform version 1 facility other service to DatamartFacility other service. */
   private static DatamartFacility.OtherService transformFacilityOtherService(
       @NonNull Facility.OtherService facilityOtherService) {
-    return containsValueOfName(DatamartFacility.OtherService.values(), facilityOtherService.name())
-        ? DatamartFacility.OtherService.valueOf(facilityOtherService.name())
-        : null;
+    return DatamartFacility.OtherService.valueOf(facilityOtherService.name());
   }
 
   /** Transform DatamartFacility patient wait times to version 1 facility patient wait times. */
@@ -407,25 +379,18 @@ public final class FacilityTransformerV1 extends BaseVersionedTransformer {
             .health(
                 (datamartFacilityServices.health() != null)
                     ? datamartFacilityServices.health().parallelStream()
-                        .filter(
-                            e ->
-                                containsValueOfName(Facility.HealthService.values(), e.name())
-                                    || checkHealthServiceNameChange(e))
                         .map(e -> transformFacilityHealthService(e))
                         .collect(Collectors.toList())
                     : null)
             .benefits(
                 (datamartFacilityServices.benefits() != null)
                     ? datamartFacilityServices.benefits().parallelStream()
-                        .filter(
-                            e -> containsValueOfName(Facility.BenefitsService.values(), e.name()))
                         .map(e -> transformFacilityBenefitsService(e))
                         .collect(Collectors.toList())
                     : null)
             .other(
                 (datamartFacilityServices.other() != null)
                     ? datamartFacilityServices.other().parallelStream()
-                        .filter(e -> containsValueOfName(Facility.OtherService.values(), e.name()))
                         .map(e -> transformFacilityOtherService(e))
                         .collect(Collectors.toList())
                     : null)
@@ -442,31 +407,18 @@ public final class FacilityTransformerV1 extends BaseVersionedTransformer {
             .health(
                 (facilityServices.health() != null)
                     ? facilityServices.health().parallelStream()
-                        .filter(
-                            e ->
-                                containsValueOfName(
-                                        DatamartFacility.HealthService.values(), e.name())
-                                    || checkHealthServiceNameChange(e))
                         .map(e -> transformFacilityHealthService(e))
                         .collect(Collectors.toList())
                     : null)
             .benefits(
                 (facilityServices.benefits() != null)
                     ? facilityServices.benefits().parallelStream()
-                        .filter(
-                            e ->
-                                containsValueOfName(
-                                    DatamartFacility.BenefitsService.values(), e.name()))
                         .map(e -> transformFacilityBenefitsService(e))
                         .collect(Collectors.toList())
                     : null)
             .other(
                 (facilityServices.other() != null)
                     ? facilityServices.other().parallelStream()
-                        .filter(
-                            e ->
-                                containsValueOfName(
-                                    DatamartFacility.OtherService.values(), e.name()))
                         .map(e -> transformFacilityOtherService(e))
                         .collect(Collectors.toList())
                     : null)
@@ -479,9 +431,7 @@ public final class FacilityTransformerV1 extends BaseVersionedTransformer {
   private static Facility.FacilityType transformFacilityType(
       DatamartFacility.FacilityType datamartFacilityType) {
     return (datamartFacilityType != null)
-        ? containsValueOfName(Facility.FacilityType.values(), datamartFacilityType.name())
-            ? Facility.FacilityType.valueOf(datamartFacilityType.name())
-            : null
+        ? Facility.FacilityType.valueOf(datamartFacilityType.name())
         : null;
   }
 
@@ -489,9 +439,7 @@ public final class FacilityTransformerV1 extends BaseVersionedTransformer {
   private static DatamartFacility.FacilityType transformFacilityType(
       Facility.FacilityType facilityType) {
     return (facilityType != null)
-        ? containsValueOfName(DatamartFacility.FacilityType.values(), facilityType.name())
-            ? DatamartFacility.FacilityType.valueOf(facilityType.name())
-            : null
+        ? DatamartFacility.FacilityType.valueOf(facilityType.name())
         : null;
   }
 
@@ -541,19 +489,11 @@ public final class FacilityTransformerV1 extends BaseVersionedTransformer {
 
   /** Transform version 1 facility type to DatamartFacility facility type. */
   private static Facility.Type transformType(DatamartFacility.Type datamartType) {
-    return (datamartType != null)
-        ? containsValueOfName(Facility.Type.values(), datamartType.name())
-            ? Facility.Type.valueOf(datamartType.name())
-            : null
-        : null;
+    return (datamartType != null) ? Facility.Type.valueOf(datamartType.name()) : null;
   }
 
   /** Transform DatamartFacility type to version 1 facility type. */
   private static DatamartFacility.Type transformType(Facility.Type type) {
-    return (type != null)
-        ? containsValueOfName(DatamartFacility.Type.values(), type.name())
-            ? DatamartFacility.Type.valueOf(type.name())
-            : null
-        : null;
+    return (type != null) ? DatamartFacility.Type.valueOf(type.name()) : null;
   }
 }

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/FacilityTransformerV1.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/FacilityTransformerV1.java
@@ -214,7 +214,7 @@ public final class FacilityTransformerV1 extends BaseVersionedTransformer {
       @NonNull DatamartFacility.BenefitsService datamartFacilityBenefitsService) {
     return containsValueOfName(
             Facility.BenefitsService.values(), datamartFacilityBenefitsService.name())
-        ? Facility.BenefitsService.valueOf(datamartFacilityBenefitsService.name())
+        ? Facility.BenefitsService.fromString(datamartFacilityBenefitsService.name())
         : null;
   }
 
@@ -223,7 +223,7 @@ public final class FacilityTransformerV1 extends BaseVersionedTransformer {
       @NonNull Facility.BenefitsService facilityBenefitsService) {
     return containsValueOfName(
             DatamartFacility.BenefitsService.values(), facilityBenefitsService.name())
-        ? DatamartFacility.BenefitsService.valueOf(facilityBenefitsService.name())
+        ? DatamartFacility.BenefitsService.fromString(facilityBenefitsService.name())
         : null;
   }
 

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/BaseDeserializer.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/BaseDeserializer.java
@@ -1,0 +1,28 @@
+package gov.va.api.lighthouse.facilities.deserializers;
+
+import static gov.va.api.lighthouse.facilities.DatamartFacilitiesJacksonConfig.createMapper;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+public abstract class BaseDeserializer<T> extends StdDeserializer<T> {
+  protected static final ObjectMapper MAPPER = createMapper();
+
+  public BaseDeserializer(Class<T> t) {
+    super(t);
+  }
+
+  public abstract T deserialize(
+      JsonParser jsonParser, DeserializationContext deserializationContext);
+
+  protected boolean isNotNull(JsonNode node) {
+    return !isNull(node);
+  }
+
+  protected boolean isNull(JsonNode node) {
+    return node == null || node.isNull();
+  }
+}

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/BaseListDeserializer.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/BaseListDeserializer.java
@@ -4,16 +4,11 @@ import static gov.va.api.lighthouse.facilities.DatamartDetailedService.INVALID_S
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import gov.va.api.lighthouse.facilities.DatamartDetailedService;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public abstract class BaseListDeserializer<T> extends StdDeserializer<T> {
-  public BaseListDeserializer() {
-    this(null);
-  }
-
+public abstract class BaseListDeserializer<T> extends BaseDeserializer<T> {
   public BaseListDeserializer(Class<T> t) {
     super(t);
   }

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartAddressDeserializer.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartAddressDeserializer.java
@@ -1,19 +1,16 @@
 package gov.va.api.lighthouse.facilities.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getAddress1;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getAddress2;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getAddress3;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import gov.va.api.lighthouse.facilities.DatamartFacility.Address;
 import lombok.SneakyThrows;
 
-public class DatamartAddressDeserializer extends StdDeserializer<Address> {
+public class DatamartAddressDeserializer extends BaseDeserializer<Address> {
   public DatamartAddressDeserializer() {
     this(null);
   }
@@ -24,9 +21,8 @@ public class DatamartAddressDeserializer extends StdDeserializer<Address> {
 
   @Override
   @SneakyThrows
-  public Address deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+  public Address deserialize(JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode address1Node = getAddress1(node);
@@ -37,15 +33,12 @@ public class DatamartAddressDeserializer extends StdDeserializer<Address> {
     JsonNode zipNode = node.get("zip");
 
     return Address.builder()
-        .address1(
-            address1Node != null ? createMapper().convertValue(address1Node, String.class) : null)
-        .address2(
-            address2Node != null ? createMapper().convertValue(address2Node, String.class) : null)
-        .address3(
-            address3Node != null ? createMapper().convertValue(address3Node, String.class) : null)
-        .city(cityNode != null ? createMapper().convertValue(cityNode, String.class) : null)
-        .state(stateNode != null ? createMapper().convertValue(stateNode, String.class) : null)
-        .zip(zipNode != null ? createMapper().convertValue(zipNode, String.class) : null)
+        .address1(isNotNull(address1Node) ? address1Node.asText() : null)
+        .address2(isNotNull(address2Node) ? address2Node.asText() : null)
+        .address3(isNotNull(address3Node) ? address3Node.asText() : null)
+        .city(isNotNull(cityNode) ? cityNode.asText() : null)
+        .state(isNotNull(stateNode) ? stateNode.asText() : null)
+        .zip(isNotNull(zipNode) ? zipNode.asText() : null)
         .build();
   }
 }

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartCmsOverlayDeserializer.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartCmsOverlayDeserializer.java
@@ -1,11 +1,9 @@
 package gov.va.api.lighthouse.facilities.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getDetailedServices;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getOpertingStatus;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -28,9 +26,8 @@ public class DatamartCmsOverlayDeserializer extends BaseListDeserializer<Datamar
   @SneakyThrows
   @SuppressWarnings("unchecked")
   public DatamartCmsOverlay deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+      JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode operatingStatusNode = getOpertingStatus(node);
@@ -40,13 +37,13 @@ public class DatamartCmsOverlayDeserializer extends BaseListDeserializer<Datamar
 
     return DatamartCmsOverlay.builder()
         .operatingStatus(
-            operatingStatusNode != null
-                ? createMapper().convertValue(operatingStatusNode, OperatingStatus.class)
+            isNotNull(operatingStatusNode)
+                ? MAPPER.convertValue(operatingStatusNode, OperatingStatus.class)
                 : null)
         .detailedServices(
-            detailedServicesNode != null
+            isNotNull(detailedServicesNode)
                 ? filterOutInvalidDetailedServices(
-                    createMapper().convertValue(detailedServicesNode, detailedServicesRef))
+                    MAPPER.convertValue(detailedServicesNode, detailedServicesRef))
                 : null)
         .build();
   }

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartDetailedServiceAddressDeserializer.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartDetailedServiceAddressDeserializer.java
@@ -1,6 +1,5 @@
 package gov.va.api.lighthouse.facilities.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getAddressLine1;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getAddressLine2;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getBuildingNameNumber;
@@ -10,15 +9,13 @@ import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getWingFloor
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getZipCode;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import gov.va.api.lighthouse.facilities.DatamartDetailedService.DetailedServiceAddress;
 import lombok.SneakyThrows;
 
 public class DatamartDetailedServiceAddressDeserializer
-    extends StdDeserializer<DetailedServiceAddress> {
+    extends BaseDeserializer<DetailedServiceAddress> {
   public DatamartDetailedServiceAddressDeserializer() {
     this(null);
   }
@@ -30,9 +27,8 @@ public class DatamartDetailedServiceAddressDeserializer
   @Override
   @SneakyThrows
   public DetailedServiceAddress deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+      JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode clinicNameNode = getClinicName(node);
@@ -46,34 +42,17 @@ public class DatamartDetailedServiceAddressDeserializer
     JsonNode countryCodeNode = getCountryCode(node);
 
     return DetailedServiceAddress.builder()
-        .clinicName(
-            clinicNameNode != null
-                ? createMapper().convertValue(clinicNameNode, String.class)
-                : null)
-        .address1(
-            addressLine1Node != null
-                ? createMapper().convertValue(addressLine1Node, String.class)
-                : null)
-        .address2(
-            addressLine2Node != null
-                ? createMapper().convertValue(addressLine2Node, String.class)
-                : null)
+        .clinicName(isNotNull(clinicNameNode) ? clinicNameNode.asText() : null)
+        .address1(isNotNull(addressLine1Node) ? addressLine1Node.asText() : null)
+        .address2(isNotNull(addressLine2Node) ? addressLine2Node.asText() : null)
         .buildingNameNumber(
-            buildingNameNumberNode != null
-                ? createMapper().convertValue(buildingNameNumberNode, String.class)
-                : null)
+            isNotNull(buildingNameNumberNode) ? buildingNameNumberNode.asText() : null)
         .wingFloorOrRoomNumber(
-            wingFloorOrRoomNumberNode != null
-                ? createMapper().convertValue(wingFloorOrRoomNumberNode, String.class)
-                : null)
-        .city(cityNode != null ? createMapper().convertValue(cityNode, String.class) : null)
-        .state(stateNode != null ? createMapper().convertValue(stateNode, String.class) : null)
-        .zipCode(
-            zipCodeNode != null ? createMapper().convertValue(zipCodeNode, String.class) : null)
-        .countryCode(
-            countryCodeNode != null
-                ? createMapper().convertValue(countryCodeNode, String.class)
-                : null)
+            isNotNull(wingFloorOrRoomNumberNode) ? wingFloorOrRoomNumberNode.asText() : null)
+        .city(isNotNull(cityNode) ? cityNode.asText() : null)
+        .state(isNotNull(stateNode) ? stateNode.asText() : null)
+        .zipCode(isNotNull(zipCodeNode) ? zipCodeNode.asText() : null)
+        .countryCode(isNotNull(countryCodeNode) ? countryCodeNode.asText() : null)
         .build();
   }
 }

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartDetailedServiceDeserializer.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartDetailedServiceDeserializer.java
@@ -1,6 +1,5 @@
 package gov.va.api.lighthouse.facilities.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.DatamartDetailedService.INVALID_SVC_ID;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getAppointmentLeadin;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getFacilityDescription;
@@ -10,15 +9,12 @@ import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getReferralR
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getServiceLocations;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getWalkInsAccepted;
 import static gov.va.api.lighthouse.facilities.collector.CovidServiceUpdater.CMS_OVERLAY_SERVICE_NAME_COVID_19;
-import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.uncapitalize;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import gov.va.api.lighthouse.facilities.DatamartDetailedService;
 import gov.va.api.lighthouse.facilities.DatamartDetailedService.AppointmentPhoneNumber;
 import gov.va.api.lighthouse.facilities.DatamartDetailedService.DetailedServiceLocation;
@@ -30,7 +26,7 @@ import java.util.List;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
 
-public class DatamartDetailedServiceDeserializer extends StdDeserializer<DatamartDetailedService> {
+public class DatamartDetailedServiceDeserializer extends BaseDeserializer<DatamartDetailedService> {
   public DatamartDetailedServiceDeserializer() {
     this(null);
   }
@@ -43,9 +39,8 @@ public class DatamartDetailedServiceDeserializer extends StdDeserializer<Datamar
   @SneakyThrows
   @SuppressWarnings("unchecked")
   public DatamartDetailedService deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+      JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode nameNode = node.get("name");
@@ -61,14 +56,12 @@ public class DatamartDetailedServiceDeserializer extends StdDeserializer<Datamar
     JsonNode serviceLocationsNode = getServiceLocations(node);
     JsonNode walkInsAcceptedNode = getWalkInsAccepted(node);
 
-    String serviceName =
-        nameNode != null ? createMapper().convertValue(nameNode, String.class) : null;
+    String serviceName = isNotNull(nameNode) ? nameNode.asText() : null;
     String serviceId =
-        serviceIdNode != null
-                && isRecognizedServiceId(createMapper().convertValue(serviceIdNode, String.class))
-            ? createMapper().convertValue(serviceIdNode, String.class)
+        isNotNull(serviceIdNode) && isRecognizedServiceId(serviceIdNode.asText())
+            ? serviceIdNode.asText()
             : // Attempt to construct service id from service name
-            serviceIdNode == null && isRecognizedServiceName(serviceName)
+            isNull(serviceIdNode) && isRecognizedServiceName(serviceName)
                 ? getServiceIdForRecognizedServiceName(serviceName)
                 : INVALID_SVC_ID;
 
@@ -78,38 +71,26 @@ public class DatamartDetailedServiceDeserializer extends StdDeserializer<Datamar
     return DatamartDetailedService.builder()
         .serviceId(serviceId)
         .name(serviceName)
-        .active(activeNode != null ? createMapper().convertValue(activeNode, Boolean.class) : false)
-        .changed(
-            changedNode != null ? createMapper().convertValue(changedNode, String.class) : null)
+        .active(isNotNull(activeNode) ? activeNode.asBoolean() : false)
+        .changed(isNotNull(changedNode) ? changedNode.asText() : null)
         .descriptionFacility(
-            descriptionFacilityNode != null
-                ? createMapper().convertValue(descriptionFacilityNode, String.class)
-                : null)
-        .appointmentLeadIn(
-            appointmentLeadInNode != null
-                ? createMapper().convertValue(appointmentLeadInNode, String.class)
-                : null)
+            isNotNull(descriptionFacilityNode) ? descriptionFacilityNode.asText() : null)
+        .appointmentLeadIn(isNotNull(appointmentLeadInNode) ? appointmentLeadInNode.asText() : null)
         .onlineSchedulingAvailable(
-            onlineSchedulingAvailableNode != null
-                ? createMapper().convertValue(onlineSchedulingAvailableNode, String.class)
+            isNotNull(onlineSchedulingAvailableNode)
+                ? onlineSchedulingAvailableNode.asText()
                 : null)
-        .path(pathNode != null ? createMapper().convertValue(pathNode, String.class) : null)
+        .path(isNotNull(pathNode) ? pathNode.asText() : null)
         .phoneNumbers(
-            phoneNumbersNode != null
-                ? createMapper().convertValue(phoneNumbersNode, appointmentNumbersRef)
-                : emptyList())
-        .referralRequired(
-            referralRequiredNode != null
-                ? createMapper().convertValue(referralRequiredNode, String.class)
+            isNotNull(phoneNumbersNode)
+                ? MAPPER.convertValue(phoneNumbersNode, appointmentNumbersRef)
                 : null)
+        .referralRequired(isNotNull(referralRequiredNode) ? referralRequiredNode.asText() : null)
         .serviceLocations(
-            serviceLocationsNode != null
-                ? createMapper().convertValue(serviceLocationsNode, serviceLocationsRef)
-                : emptyList())
-        .walkInsAccepted(
-            walkInsAcceptedNode != null
-                ? createMapper().convertValue(walkInsAcceptedNode, String.class)
+            isNotNull(serviceLocationsNode)
+                ? MAPPER.convertValue(serviceLocationsNode, serviceLocationsRef)
                 : null)
+        .walkInsAccepted(isNotNull(walkInsAcceptedNode) ? walkInsAcceptedNode.asText() : null)
         .build();
   }
 
@@ -124,7 +105,7 @@ public class DatamartDetailedServiceDeserializer extends StdDeserializer<Datamar
                 : Arrays.stream(BenefitsService.values())
                         .parallel()
                         .anyMatch(bs -> bs.name().equalsIgnoreCase(name))
-                    ? BenefitsService.valueOf(name).name()
+                    ? BenefitsService.fromString(name).name()
                     : Arrays.stream(OtherService.values())
                             .parallel()
                             .anyMatch(os -> os.name().equalsIgnoreCase(name))

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartDetailedServiceEmailContactDeserializer.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartDetailedServiceEmailContactDeserializer.java
@@ -1,19 +1,16 @@
 package gov.va.api.lighthouse.facilities.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getEmailAddress;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getEmailLabel;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import gov.va.api.lighthouse.facilities.DatamartDetailedService.DetailedServiceEmailContact;
 import lombok.SneakyThrows;
 
 public class DatamartDetailedServiceEmailContactDeserializer
-    extends StdDeserializer<DetailedServiceEmailContact> {
+    extends BaseDeserializer<DetailedServiceEmailContact> {
   public DatamartDetailedServiceEmailContactDeserializer() {
     this(null);
   }
@@ -25,23 +22,16 @@ public class DatamartDetailedServiceEmailContactDeserializer
   @Override
   @SneakyThrows
   public DetailedServiceEmailContact deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+      JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode emailAddressNode = getEmailAddress(node);
     JsonNode emailLabelNode = getEmailLabel(node);
 
     return DetailedServiceEmailContact.builder()
-        .emailAddress(
-            emailAddressNode != null
-                ? createMapper().convertValue(emailAddressNode, String.class)
-                : null)
-        .emailLabel(
-            emailLabelNode != null
-                ? createMapper().convertValue(emailLabelNode, String.class)
-                : null)
+        .emailAddress(isNotNull(emailAddressNode) ? emailAddressNode.asText() : null)
+        .emailLabel(isNotNull(emailLabelNode) ? emailLabelNode.asText() : null)
         .build();
   }
 }

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartDetailedServiceHoursDeserializer.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartDetailedServiceHoursDeserializer.java
@@ -1,6 +1,5 @@
 package gov.va.api.lighthouse.facilities.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getFridayHours;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getMondayHours;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getSaturdayHours;
@@ -10,15 +9,13 @@ import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getTuesdayHo
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getWednesdayHours;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import gov.va.api.lighthouse.facilities.DatamartDetailedService.DetailedServiceHours;
 import lombok.SneakyThrows;
 
 public class DatamartDetailedServiceHoursDeserializer
-    extends StdDeserializer<DetailedServiceHours> {
+    extends BaseDeserializer<DetailedServiceHours> {
   public DatamartDetailedServiceHoursDeserializer() {
     this(null);
   }
@@ -30,9 +27,8 @@ public class DatamartDetailedServiceHoursDeserializer
   @Override
   @SneakyThrows
   public DetailedServiceHours deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+      JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode mondayHoursNode = getMondayHours(node);
@@ -44,34 +40,13 @@ public class DatamartDetailedServiceHoursDeserializer
     JsonNode sundayHoursNode = getSundayHours(node);
 
     return DetailedServiceHours.builder()
-        .monday(
-            mondayHoursNode != null
-                ? createMapper().convertValue(mondayHoursNode, String.class)
-                : null)
-        .tuesday(
-            tuesdayHoursNode != null
-                ? createMapper().convertValue(tuesdayHoursNode, String.class)
-                : null)
-        .wednesday(
-            wednesdayHoursNode != null
-                ? createMapper().convertValue(wednesdayHoursNode, String.class)
-                : null)
-        .thursday(
-            thursdayHoursNode != null
-                ? createMapper().convertValue(thursdayHoursNode, String.class)
-                : null)
-        .friday(
-            fridayHoursNode != null
-                ? createMapper().convertValue(fridayHoursNode, String.class)
-                : null)
-        .saturday(
-            saturdayHoursNode != null
-                ? createMapper().convertValue(saturdayHoursNode, String.class)
-                : null)
-        .sunday(
-            sundayHoursNode != null
-                ? createMapper().convertValue(sundayHoursNode, String.class)
-                : null)
+        .monday(isNotNull(mondayHoursNode) ? mondayHoursNode.asText() : null)
+        .tuesday(isNotNull(tuesdayHoursNode) ? tuesdayHoursNode.asText() : null)
+        .wednesday(isNotNull(wednesdayHoursNode) ? wednesdayHoursNode.asText() : null)
+        .thursday(isNotNull(thursdayHoursNode) ? thursdayHoursNode.asText() : null)
+        .friday(isNotNull(fridayHoursNode) ? fridayHoursNode.asText() : null)
+        .saturday(isNotNull(saturdayHoursNode) ? saturdayHoursNode.asText() : null)
+        .sunday(isNotNull(sundayHoursNode) ? sundayHoursNode.asText() : null)
         .build();
   }
 }

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartDetailedServiceLocationDeserializer.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartDetailedServiceLocationDeserializer.java
@@ -1,19 +1,15 @@
 package gov.va.api.lighthouse.facilities.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getAdditionalHoursInfo;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getEmailContacts;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getFacilityServiceHours;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getPhoneNumbers;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getServiceLocationAddress;
-import static java.util.Collections.emptyList;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import gov.va.api.lighthouse.facilities.DatamartDetailedService.AppointmentPhoneNumber;
 import gov.va.api.lighthouse.facilities.DatamartDetailedService.DetailedServiceAddress;
 import gov.va.api.lighthouse.facilities.DatamartDetailedService.DetailedServiceEmailContact;
@@ -23,7 +19,7 @@ import java.util.List;
 import lombok.SneakyThrows;
 
 public class DatamartDetailedServiceLocationDeserializer
-    extends StdDeserializer<DetailedServiceLocation> {
+    extends BaseDeserializer<DetailedServiceLocation> {
   public DatamartDetailedServiceLocationDeserializer() {
     this(null);
   }
@@ -35,9 +31,8 @@ public class DatamartDetailedServiceLocationDeserializer
   @Override
   @SneakyThrows
   public DetailedServiceLocation deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+      JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode additionalHoursInfoNode = getAdditionalHoursInfo(node);
@@ -51,25 +46,22 @@ public class DatamartDetailedServiceLocationDeserializer
 
     return DetailedServiceLocation.builder()
         .additionalHoursInfo(
-            additionalHoursInfoNode != null
-                ? createMapper().convertValue(additionalHoursInfoNode, String.class)
-                : null)
+            isNotNull(additionalHoursInfoNode) ? additionalHoursInfoNode.asText() : null)
         .emailContacts(
-            emailContactsNode != null
-                ? createMapper().convertValue(emailContactsNode, emailContactsRef)
-                : emptyList())
+            isNotNull(emailContactsNode)
+                ? MAPPER.convertValue(emailContactsNode, emailContactsRef)
+                : null)
         .facilityServiceHours(
-            facilityServiceHoursNode != null
-                ? createMapper().convertValue(facilityServiceHoursNode, DetailedServiceHours.class)
+            isNotNull(facilityServiceHoursNode)
+                ? MAPPER.convertValue(facilityServiceHoursNode, DetailedServiceHours.class)
                 : null)
         .appointmentPhoneNumbers(
-            appointmentPhoneNumbersNode != null
-                ? createMapper().convertValue(appointmentPhoneNumbersNode, phoneNumbersRef)
-                : emptyList())
+            isNotNull(appointmentPhoneNumbersNode)
+                ? MAPPER.convertValue(appointmentPhoneNumbersNode, phoneNumbersRef)
+                : null)
         .serviceLocationAddress(
-            serviceLocationAddressNode != null
-                ? createMapper()
-                    .convertValue(serviceLocationAddressNode, DetailedServiceAddress.class)
+            isNotNull(serviceLocationAddressNode)
+                ? MAPPER.convertValue(serviceLocationAddressNode, DetailedServiceAddress.class)
                 : null)
         .build();
   }

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartFacilityAttributesDeserializer.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartFacilityAttributesDeserializer.java
@@ -1,6 +1,5 @@
 package gov.va.api.lighthouse.facilities.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getActiveStatus;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getDetailedServices;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getFacilityType;
@@ -10,7 +9,6 @@ import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getTimeZone;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getWaitTimes;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -43,9 +41,8 @@ public class DatamartFacilityAttributesDeserializer
   @SneakyThrows
   @SuppressWarnings("unchecked")
   public FacilityAttributes deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+      JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode nameNode = node.get("name");
@@ -71,60 +68,48 @@ public class DatamartFacilityAttributesDeserializer
     TypeReference<List<DatamartDetailedService>> detailedServicesRef = new TypeReference<>() {};
 
     return FacilityAttributes.builder()
-        .name(nameNode != null ? createMapper().convertValue(nameNode, String.class) : null)
+        .name(isNotNull(nameNode) ? nameNode.asText() : null)
         .facilityType(
-            facilityTypeNode != null
-                ? createMapper().convertValue(facilityTypeNode, FacilityType.class)
+            isNotNull(facilityTypeNode)
+                ? MAPPER.convertValue(facilityTypeNode, FacilityType.class)
                 : null)
-        .classification(
-            classificationNode != null
-                ? createMapper().convertValue(classificationNode, String.class)
-                : null)
-        .website(
-            websiteNode != null ? createMapper().convertValue(websiteNode, String.class) : null)
+        .classification(isNotNull(classificationNode) ? classificationNode.asText() : null)
+        .website(isNotNull(websiteNode) ? websiteNode.asText() : null)
         .latitude(
-            latitudeNode != null
-                ? createMapper().convertValue(latitudeNode, BigDecimal.class)
-                : null)
+            isNotNull(latitudeNode) ? MAPPER.convertValue(latitudeNode, BigDecimal.class) : null)
         .longitude(
-            longitudeNode != null
-                ? createMapper().convertValue(longitudeNode, BigDecimal.class)
-                : null)
-        .timeZone(
-            timeZoneNode != null ? createMapper().convertValue(timeZoneNode, String.class) : null)
-        .address(
-            addressNode != null ? createMapper().convertValue(addressNode, Addresses.class) : null)
-        .phone(phoneNode != null ? createMapper().convertValue(phoneNode, Phone.class) : null)
-        .hours(hoursNode != null ? createMapper().convertValue(hoursNode, Hours.class) : null)
+            isNotNull(longitudeNode) ? MAPPER.convertValue(longitudeNode, BigDecimal.class) : null)
+        .timeZone(isNotNull(timeZoneNode) ? timeZoneNode.asText() : null)
+        .address(isNotNull(addressNode) ? MAPPER.convertValue(addressNode, Addresses.class) : null)
+        .phone(isNotNull(phoneNode) ? MAPPER.convertValue(phoneNode, Phone.class) : null)
+        .hours(isNotNull(hoursNode) ? MAPPER.convertValue(hoursNode, Hours.class) : null)
         .operationalHoursSpecialInstructions(
-            operationalHoursSpecialInstructionsNode != null
-                ? createMapper().convertValue(operationalHoursSpecialInstructionsNode, String.class)
+            isNotNull(operationalHoursSpecialInstructionsNode)
+                ? operationalHoursSpecialInstructionsNode.asText()
                 : null)
         .services(
-            servicesNode != null ? createMapper().convertValue(servicesNode, Services.class) : null)
+            isNotNull(servicesNode) ? MAPPER.convertValue(servicesNode, Services.class) : null)
         .satisfaction(
-            satisfactionNode != null
-                ? createMapper().convertValue(satisfactionNode, Satisfaction.class)
+            isNotNull(satisfactionNode)
+                ? MAPPER.convertValue(satisfactionNode, Satisfaction.class)
                 : null)
         .waitTimes(
-            waitTimesNode != null
-                ? createMapper().convertValue(waitTimesNode, WaitTimes.class)
-                : null)
-        .mobile(mobileNode != null ? createMapper().convertValue(mobileNode, Boolean.class) : null)
+            isNotNull(waitTimesNode) ? MAPPER.convertValue(waitTimesNode, WaitTimes.class) : null)
+        .mobile(isNotNull(mobileNode) ? mobileNode.asBoolean() : null)
         .activeStatus(
-            activeStatusNode != null
-                ? createMapper().convertValue(activeStatusNode, ActiveStatus.class)
+            isNotNull(activeStatusNode)
+                ? MAPPER.convertValue(activeStatusNode, ActiveStatus.class)
                 : null)
         .operatingStatus(
-            operatingStatusNode != null
-                ? createMapper().convertValue(operatingStatusNode, OperatingStatus.class)
+            isNotNull(operatingStatusNode)
+                ? MAPPER.convertValue(operatingStatusNode, OperatingStatus.class)
                 : null)
         .detailedServices(
-            detailedServicesNode != null
+            isNotNull(detailedServicesNode)
                 ? filterOutInvalidDetailedServices(
-                    createMapper().convertValue(detailedServicesNode, detailedServicesRef))
+                    MAPPER.convertValue(detailedServicesNode, detailedServicesRef))
                 : null)
-        .visn(visnNode != null ? createMapper().convertValue(visnNode, String.class) : null)
+        .visn(isNotNull(visnNode) ? visnNode.asText() : null)
         .build();
   }
 }

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartHoursDeserializer.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartHoursDeserializer.java
@@ -1,6 +1,5 @@
 package gov.va.api.lighthouse.facilities.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getFridayHours;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getMondayHours;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getSaturdayHours;
@@ -10,14 +9,12 @@ import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getTuesdayHo
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getWednesdayHours;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import gov.va.api.lighthouse.facilities.DatamartFacility.Hours;
 import lombok.SneakyThrows;
 
-public class DatamartHoursDeserializer extends StdDeserializer<Hours> {
+public class DatamartHoursDeserializer extends BaseDeserializer<Hours> {
   public DatamartHoursDeserializer() {
     this(null);
   }
@@ -28,9 +25,8 @@ public class DatamartHoursDeserializer extends StdDeserializer<Hours> {
 
   @Override
   @SneakyThrows
-  public Hours deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+  public Hours deserialize(JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode mondayHoursNode = getMondayHours(node);
@@ -42,34 +38,13 @@ public class DatamartHoursDeserializer extends StdDeserializer<Hours> {
     JsonNode sundayHoursNode = getSundayHours(node);
 
     return Hours.builder()
-        .monday(
-            mondayHoursNode != null
-                ? createMapper().convertValue(mondayHoursNode, String.class)
-                : null)
-        .tuesday(
-            tuesdayHoursNode != null
-                ? createMapper().convertValue(tuesdayHoursNode, String.class)
-                : null)
-        .wednesday(
-            wednesdayHoursNode != null
-                ? createMapper().convertValue(wednesdayHoursNode, String.class)
-                : null)
-        .thursday(
-            thursdayHoursNode != null
-                ? createMapper().convertValue(thursdayHoursNode, String.class)
-                : null)
-        .friday(
-            fridayHoursNode != null
-                ? createMapper().convertValue(fridayHoursNode, String.class)
-                : null)
-        .saturday(
-            saturdayHoursNode != null
-                ? createMapper().convertValue(saturdayHoursNode, String.class)
-                : null)
-        .sunday(
-            sundayHoursNode != null
-                ? createMapper().convertValue(sundayHoursNode, String.class)
-                : null)
+        .monday(isNotNull(mondayHoursNode) ? mondayHoursNode.asText() : null)
+        .tuesday(isNotNull(tuesdayHoursNode) ? tuesdayHoursNode.asText() : null)
+        .wednesday(isNotNull(wednesdayHoursNode) ? wednesdayHoursNode.asText() : null)
+        .thursday(isNotNull(thursdayHoursNode) ? thursdayHoursNode.asText() : null)
+        .friday(isNotNull(fridayHoursNode) ? fridayHoursNode.asText() : null)
+        .saturday(isNotNull(saturdayHoursNode) ? saturdayHoursNode.asText() : null)
+        .sunday(isNotNull(sundayHoursNode) ? sundayHoursNode.asText() : null)
         .build();
   }
 }

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartOperatingStatusDeserializer.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartOperatingStatusDeserializer.java
@@ -1,18 +1,15 @@
 package gov.va.api.lighthouse.facilities.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getAdditionalInfo;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import gov.va.api.lighthouse.facilities.DatamartFacility.OperatingStatus;
 import gov.va.api.lighthouse.facilities.DatamartFacility.OperatingStatusCode;
 import lombok.SneakyThrows;
 
-public class DatamartOperatingStatusDeserializer extends StdDeserializer<OperatingStatus> {
+public class DatamartOperatingStatusDeserializer extends BaseDeserializer<OperatingStatus> {
   public DatamartOperatingStatusDeserializer() {
     this(null);
   }
@@ -23,24 +20,16 @@ public class DatamartOperatingStatusDeserializer extends StdDeserializer<Operati
 
   @Override
   @SneakyThrows
-  public OperatingStatus deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+  public OperatingStatus deserialize(JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode codeNode = node.get("code");
     JsonNode additionalInfoNode = getAdditionalInfo(node);
 
     return OperatingStatus.builder()
-        .code(
-            codeNode != null
-                ? createMapper().convertValue(codeNode, OperatingStatusCode.class)
-                : null)
-        .additionalInfo(
-            additionalInfoNode != null
-                ? createMapper().convertValue(additionalInfoNode, String.class)
-                : null)
+        .code(isNotNull(codeNode) ? MAPPER.convertValue(codeNode, OperatingStatusCode.class) : null)
+        .additionalInfo(isNotNull(additionalInfoNode) ? additionalInfoNode.asText() : null)
         .build();
   }
 }

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartPatientSatisfactionDeserializer.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartPatientSatisfactionDeserializer.java
@@ -1,21 +1,18 @@
 package gov.va.api.lighthouse.facilities.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getPrimaryCareRoutine;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getPrimaryCareUrgent;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getSpecialtyCareRoutine;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getSpecialtyCareUrgent;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import gov.va.api.lighthouse.facilities.DatamartFacility.PatientSatisfaction;
 import java.math.BigDecimal;
 import lombok.SneakyThrows;
 
-public class DatamartPatientSatisfactionDeserializer extends StdDeserializer<PatientSatisfaction> {
+public class DatamartPatientSatisfactionDeserializer extends BaseDeserializer<PatientSatisfaction> {
   public DatamartPatientSatisfactionDeserializer() {
     this(null);
   }
@@ -27,9 +24,8 @@ public class DatamartPatientSatisfactionDeserializer extends StdDeserializer<Pat
   @Override
   @SneakyThrows
   public PatientSatisfaction deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+      JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode primaryCareUrgentNode = getPrimaryCareUrgent(node);
@@ -39,20 +35,20 @@ public class DatamartPatientSatisfactionDeserializer extends StdDeserializer<Pat
 
     return PatientSatisfaction.builder()
         .primaryCareUrgent(
-            primaryCareUrgentNode != null
-                ? createMapper().convertValue(primaryCareUrgentNode, BigDecimal.class)
+            isNotNull(primaryCareUrgentNode)
+                ? MAPPER.convertValue(primaryCareUrgentNode, BigDecimal.class)
                 : null)
         .specialtyCareUrgent(
-            specialtyCareUrgentNode != null
-                ? createMapper().convertValue(specialtyCareUrgentNode, BigDecimal.class)
+            isNotNull(specialtyCareUrgentNode)
+                ? MAPPER.convertValue(specialtyCareUrgentNode, BigDecimal.class)
                 : null)
         .primaryCareRoutine(
-            primaryCareRoutineNode != null
-                ? createMapper().convertValue(primaryCareRoutineNode, BigDecimal.class)
+            isNotNull(primaryCareRoutineNode)
+                ? MAPPER.convertValue(primaryCareRoutineNode, BigDecimal.class)
                 : null)
         .specialtyCareRoutine(
-            specialtyCareRoutineNode != null
-                ? createMapper().convertValue(specialtyCareRoutineNode, BigDecimal.class)
+            isNotNull(specialtyCareRoutineNode)
+                ? MAPPER.convertValue(specialtyCareRoutineNode, BigDecimal.class)
                 : null)
         .build();
   }

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartPhoneDeserializer.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartPhoneDeserializer.java
@@ -1,20 +1,17 @@
 package gov.va.api.lighthouse.facilities.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getAfterHours;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getEnrollmentCoordinator;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getMentalHealthClinic;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getPatientAdvocate;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import gov.va.api.lighthouse.facilities.DatamartFacility.Phone;
 import lombok.SneakyThrows;
 
-public class DatamartPhoneDeserializer extends StdDeserializer<Phone> {
+public class DatamartPhoneDeserializer extends BaseDeserializer<Phone> {
   public DatamartPhoneDeserializer() {
     this(null);
   }
@@ -25,9 +22,8 @@ public class DatamartPhoneDeserializer extends StdDeserializer<Phone> {
 
   @Override
   @SneakyThrows
-  public Phone deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+  public Phone deserialize(JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode faxNode = node.get("fax");
@@ -39,26 +35,15 @@ public class DatamartPhoneDeserializer extends StdDeserializer<Phone> {
     JsonNode enrollmentCoordinator = getEnrollmentCoordinator(node);
 
     return Phone.builder()
-        .fax(faxNode != null ? createMapper().convertValue(faxNode, String.class) : null)
-        .main(mainNode != null ? createMapper().convertValue(mainNode, String.class) : null)
-        .pharmacy(
-            pharmacyNode != null ? createMapper().convertValue(pharmacyNode, String.class) : null)
-        .afterHours(
-            afterHoursNode != null
-                ? createMapper().convertValue(afterHoursNode, String.class)
-                : null)
-        .patientAdvocate(
-            patientAdvocateNode != null
-                ? createMapper().convertValue(patientAdvocateNode, String.class)
-                : null)
+        .fax(isNotNull(faxNode) ? faxNode.asText() : null)
+        .main(isNotNull(mainNode) ? mainNode.asText() : null)
+        .pharmacy(isNotNull(pharmacyNode) ? pharmacyNode.asText() : null)
+        .afterHours(isNotNull(afterHoursNode) ? afterHoursNode.asText() : null)
+        .patientAdvocate(isNotNull(patientAdvocateNode) ? patientAdvocateNode.asText() : null)
         .mentalHealthClinic(
-            mentalHealthClinicNode != null
-                ? createMapper().convertValue(mentalHealthClinicNode, String.class)
-                : null)
+            isNotNull(mentalHealthClinicNode) ? mentalHealthClinicNode.asText() : null)
         .enrollmentCoordinator(
-            enrollmentCoordinator != null
-                ? createMapper().convertValue(enrollmentCoordinator, String.class)
-                : null)
+            isNotNull(enrollmentCoordinator) ? enrollmentCoordinator.asText() : null)
         .build();
   }
 }

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartSatisfactionDeserializer.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartSatisfactionDeserializer.java
@@ -1,19 +1,16 @@
 package gov.va.api.lighthouse.facilities.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getEffectiveDate;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import gov.va.api.lighthouse.facilities.DatamartFacility.PatientSatisfaction;
 import gov.va.api.lighthouse.facilities.DatamartFacility.Satisfaction;
 import java.time.LocalDate;
 import lombok.SneakyThrows;
 
-public class DatamartSatisfactionDeserializer extends StdDeserializer<Satisfaction> {
+public class DatamartSatisfactionDeserializer extends BaseDeserializer<Satisfaction> {
   public DatamartSatisfactionDeserializer() {
     this(null);
   }
@@ -24,10 +21,8 @@ public class DatamartSatisfactionDeserializer extends StdDeserializer<Satisfacti
 
   @Override
   @SneakyThrows
-  public Satisfaction deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+  public Satisfaction deserialize(JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode healthNode = node.get("health");
@@ -35,12 +30,12 @@ public class DatamartSatisfactionDeserializer extends StdDeserializer<Satisfacti
 
     return Satisfaction.builder()
         .health(
-            healthNode != null
-                ? createMapper().convertValue(healthNode, PatientSatisfaction.class)
+            isNotNull(healthNode)
+                ? MAPPER.convertValue(healthNode, PatientSatisfaction.class)
                 : null)
         .effectiveDate(
-            effectiveDateNode != null
-                ? createMapper().convertValue(effectiveDateNode, LocalDate.class)
+            isNotNull(effectiveDateNode)
+                ? MAPPER.convertValue(effectiveDateNode, LocalDate.class)
                 : null)
         .build();
   }

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartServicesDeserializer.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartServicesDeserializer.java
@@ -1,15 +1,11 @@
 package gov.va.api.lighthouse.facilities.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getLastUpdated;
-import static java.util.Collections.emptyList;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import gov.va.api.lighthouse.facilities.DatamartFacility.BenefitsService;
 import gov.va.api.lighthouse.facilities.DatamartFacility.HealthService;
 import gov.va.api.lighthouse.facilities.DatamartFacility.OtherService;
@@ -18,7 +14,7 @@ import java.time.LocalDate;
 import java.util.List;
 import lombok.SneakyThrows;
 
-public class DatamartServicesDeserializer extends StdDeserializer<Services> {
+public class DatamartServicesDeserializer extends BaseDeserializer<Services> {
   public DatamartServicesDeserializer() {
     this(null);
   }
@@ -30,10 +26,8 @@ public class DatamartServicesDeserializer extends StdDeserializer<Services> {
   @Override
   @SneakyThrows
   @SuppressWarnings("unchecked")
-  public Services deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+  public Services deserialize(JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode benefitsNode = node.get("benefits");
@@ -46,16 +40,12 @@ public class DatamartServicesDeserializer extends StdDeserializer<Services> {
     TypeReference<List<OtherService>> otherRef = new TypeReference<>() {};
 
     return Services.builder()
-        .benefits(
-            healthNode != null
-                ? createMapper().convertValue(benefitsNode, benefitsRef)
-                : emptyList())
-        .health(
-            healthNode != null ? createMapper().convertValue(healthNode, healthRef) : emptyList())
-        .other(healthNode != null ? createMapper().convertValue(otherNode, otherRef) : emptyList())
+        .benefits(isNotNull(benefitsNode) ? MAPPER.convertValue(benefitsNode, benefitsRef) : null)
+        .health(isNotNull(healthNode) ? MAPPER.convertValue(healthNode, healthRef) : null)
+        .other(isNotNull(otherNode) ? MAPPER.convertValue(otherNode, otherRef) : null)
         .lastUpdated(
-            lastUpdatedNode != null
-                ? createMapper().convertValue(lastUpdatedNode, LocalDate.class)
+            isNotNull(lastUpdatedNode)
+                ? MAPPER.convertValue(lastUpdatedNode, LocalDate.class)
                 : null)
         .build();
   }

--- a/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartWaitTimesDeserializer.java
+++ b/facilities/src/main/java/gov/va/api/lighthouse/facilities/deserializers/DatamartWaitTimesDeserializer.java
@@ -1,22 +1,18 @@
 package gov.va.api.lighthouse.facilities.deserializers;
 
-import static gov.va.api.health.autoconfig.configuration.JacksonConfig.createMapper;
 import static gov.va.api.lighthouse.facilities.api.DeserializerUtil.getEffectiveDate;
-import static java.util.Collections.emptyList;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import gov.va.api.lighthouse.facilities.DatamartFacility.PatientWaitTime;
 import gov.va.api.lighthouse.facilities.DatamartFacility.WaitTimes;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.SneakyThrows;
 
-public class DatamartWaitTimesDeserializer extends StdDeserializer<WaitTimes> {
+public class DatamartWaitTimesDeserializer extends BaseDeserializer<WaitTimes> {
   public DatamartWaitTimesDeserializer() {
     this(null);
   }
@@ -28,10 +24,8 @@ public class DatamartWaitTimesDeserializer extends StdDeserializer<WaitTimes> {
   @Override
   @SneakyThrows
   @SuppressWarnings("unchecked")
-  public WaitTimes deserialize(
-      JsonParser jsonParser, DeserializationContext deserializationContext) {
-    ObjectCodec oc = jsonParser.getCodec();
-    JsonNode node = oc.readTree(jsonParser);
+  public WaitTimes deserialize(JsonParser jp, DeserializationContext deserializationContext) {
+    JsonNode node = jp.getCodec().readTree(jp);
 
     // Read values using snake_case or camelCase representations
     JsonNode healthNode = node.get("health");
@@ -40,11 +34,10 @@ public class DatamartWaitTimesDeserializer extends StdDeserializer<WaitTimes> {
     TypeReference<List<PatientWaitTime>> healthRef = new TypeReference<>() {};
 
     return WaitTimes.builder()
-        .health(
-            healthNode != null ? createMapper().convertValue(healthNode, healthRef) : emptyList())
+        .health(isNotNull(healthNode) ? MAPPER.convertValue(healthNode, healthRef) : null)
         .effectiveDate(
-            effectiveDateNode != null
-                ? createMapper().convertValue(effectiveDateNode, LocalDate.class)
+            isNotNull(effectiveDateNode)
+                ? MAPPER.convertValue(effectiveDateNode, LocalDate.class)
                 : null)
         .build();
   }

--- a/facilities/src/test/java/gov/va/api/lighthouse/facilities/FacilityOverlayV0Test.java
+++ b/facilities/src/test/java/gov/va/api/lighthouse/facilities/FacilityOverlayV0Test.java
@@ -1,6 +1,5 @@
 package gov.va.api.lighthouse.facilities;
 
-import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.uncapitalize;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,7 +44,7 @@ public class FacilityOverlayV0Test {
     assertStatus(
         null,
         OperatingStatus.builder().code(OperatingStatusCode.NORMAL).build(),
-        emptyList(),
+        null,
         entity(fromActiveStatus(null), overlay(null, false)));
   }
 
@@ -150,17 +149,17 @@ public class FacilityOverlayV0Test {
     assertStatus(
         ActiveStatus.A,
         OperatingStatus.builder().code(OperatingStatusCode.NORMAL).build(),
-        emptyList(),
+        null,
         entity(fromActiveStatus(ActiveStatus.A), null));
     assertStatus(
         ActiveStatus.T,
         OperatingStatus.builder().code(OperatingStatusCode.CLOSED).build(),
-        emptyList(),
+        null,
         entity(fromActiveStatus(ActiveStatus.T), null));
     assertStatus(
         null,
         OperatingStatus.builder().code(OperatingStatusCode.NORMAL).build(),
-        emptyList(),
+        null,
         entity(fromActiveStatus(null), null));
   }
 

--- a/facilities/src/test/java/gov/va/api/lighthouse/facilities/FacilityOverlayV1Test.java
+++ b/facilities/src/test/java/gov/va/api/lighthouse/facilities/FacilityOverlayV1Test.java
@@ -1,6 +1,5 @@
 package gov.va.api.lighthouse.facilities;
 
-import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.uncapitalize;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,14 +28,14 @@ public class FacilityOverlayV1Test {
     assertStatus(
         ActiveStatus.T,
         op(OperatingStatusCode.CLOSED, null),
-        emptyList(),
+        null,
         entity(
             fromActiveStatus(ActiveStatus.T),
             overlay(op(OperatingStatusCode.NORMAL, "neato"), false)));
     assertStatus(
         ActiveStatus.T,
         op(OperatingStatusCode.CLOSED, null),
-        emptyList(),
+        null,
         entity(
             fromActiveStatus(ActiveStatus.T),
             overlay(op(OperatingStatusCode.NOTICE, "neato"), false)));
@@ -76,7 +75,7 @@ public class FacilityOverlayV1Test {
     assertStatus(
         null,
         OperatingStatus.builder().code(OperatingStatusCode.NORMAL).build(),
-        emptyList(),
+        null,
         entity(fromActiveStatus(null), overlay(null, false)));
   }
 
@@ -183,17 +182,17 @@ public class FacilityOverlayV1Test {
     assertStatus(
         ActiveStatus.A,
         OperatingStatus.builder().code(OperatingStatusCode.NORMAL).build(),
-        emptyList(),
+        null,
         entity(fromActiveStatus(ActiveStatus.A), null));
     assertStatus(
         ActiveStatus.T,
         OperatingStatus.builder().code(OperatingStatusCode.CLOSED).build(),
-        emptyList(),
+        null,
         entity(fromActiveStatus(ActiveStatus.T), null));
     assertStatus(
         null,
         OperatingStatus.builder().code(OperatingStatusCode.NORMAL).build(),
-        emptyList(),
+        null,
         entity(fromActiveStatus(null), null));
   }
 

--- a/facilities/src/test/java/gov/va/api/lighthouse/facilities/SerializationV1Test.java
+++ b/facilities/src/test/java/gov/va/api/lighthouse/facilities/SerializationV1Test.java
@@ -1,7 +1,6 @@
 package gov.va.api.lighthouse.facilities;
 
 import static gov.va.api.lighthouse.facilities.FacilitiesJacksonConfigV1.createMapper;
-import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -34,12 +33,8 @@ public class SerializationV1Test {
   @Test
   @SneakyThrows
   void jacksonConfigQuietlyMap() {
-    DetailedService emptyDetailedService =
-        DetailedService.builder()
-            .serviceId(DetailedService.INVALID_SVC_ID)
-            .phoneNumbers(emptyList())
-            .serviceLocations(emptyList())
-            .build();
+    var emptyDetailedService =
+        DetailedService.builder().serviceId(DetailedService.INVALID_SVC_ID).build();
     String json =
         FacilitiesJacksonConfigV1.quietlyWriteValueAsString(
             FacilitiesJacksonConfigV1.createMapper(), emptyDetailedService);

--- a/facilities/src/test/java/gov/va/api/lighthouse/facilities/collector/CmsOverlayCollectorTest.java
+++ b/facilities/src/test/java/gov/va/api/lighthouse/facilities/collector/CmsOverlayCollectorTest.java
@@ -1,6 +1,7 @@
 package gov.va.api.lighthouse.facilities.collector;
 
 import static gov.va.api.lighthouse.facilities.collector.CovidServiceUpdater.CMS_OVERLAY_SERVICE_NAME_COVID_19;
+import static java.util.Collections.emptyMap;
 import static org.apache.commons.lang3.StringUtils.uncapitalize;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -14,7 +15,6 @@ import gov.va.api.lighthouse.facilities.DatamartFacilitiesJacksonConfig;
 import gov.va.api.lighthouse.facilities.DatamartFacility;
 import gov.va.api.lighthouse.facilities.FacilityEntity;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -36,7 +36,7 @@ public class CmsOverlayCollectorTest {
     when(mockEntity.cmsServices()).thenThrow(new NullPointerException("oh noes"));
     when(mockCmsOverlayRepository.findAll()).thenReturn(List.of(mockEntity));
     CmsOverlayCollector collector = new CmsOverlayCollector(mockCmsOverlayRepository);
-    assertThat(collector.loadAndUpdateCmsOverlays()).isEqualTo(Collections.emptyMap());
+    assertThat(collector.loadAndUpdateCmsOverlays()).isEqualTo(emptyMap());
   }
 
   @Test

--- a/facilities/src/test/java/gov/va/api/lighthouse/facilities/deserializers/DeserializerTest.java
+++ b/facilities/src/test/java/gov/va/api/lighthouse/facilities/deserializers/DeserializerTest.java
@@ -85,7 +85,7 @@ public class DeserializerTest {
                 new DatamartAddressDeserializer(null).deserialize(null, mockDeserializationContext))
         .isInstanceOf(NullPointerException.class)
         .hasMessage(
-            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jsonParser\" is null");
+            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jp\" is null");
   }
 
   @Test
@@ -98,8 +98,6 @@ public class DeserializerTest {
                     DatamartDetailedService.builder()
                         .serviceId(uncapitalize(BenefitsService.Pensions.name()))
                         .name(BenefitsService.Pensions.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -110,6 +108,16 @@ public class DeserializerTest {
         "{\"detailed_services\":[" + "{\"serviceId\":\"pensions\",\"name\":\"Pensions\"}" + "]}",
         DatamartCmsOverlay.class,
         overlay);
+    overlay =
+        DatamartCmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":[" + "{\"name\":\"Pensions\",\"appointment_phones\":[]}" + "]}",
         DatamartCmsOverlay.class,
@@ -120,6 +128,17 @@ public class DeserializerTest {
             + "]}",
         DatamartCmsOverlay.class,
         overlay);
+    overlay =
+        DatamartCmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Pensions\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -145,7 +164,7 @@ public class DeserializerTest {
                     .deserialize(null, mock(DeserializationContext.class)))
         .isInstanceOf(NullPointerException.class)
         .hasMessage(
-            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jsonParser\" is null");
+            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jp\" is null");
   }
 
   @Test
@@ -155,14 +174,18 @@ public class DeserializerTest {
         DatamartDetailedService.builder()
             .serviceId(uncapitalize(BenefitsService.Pensions.name()))
             .name(BenefitsService.Pensions.name())
-            .phoneNumbers(emptyList())
-            .serviceLocations(emptyList())
             .build();
     assertJson("{\"name\":\"Pensions\"}", DatamartDetailedService.class, detailedService);
     assertJson(
         "{\"serviceId\":\"pensions\",\"name\":\"Pensions\"}",
         DatamartDetailedService.class,
         detailedService);
+    detailedService =
+        DatamartDetailedService.builder()
+            .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+            .name(BenefitsService.Pensions.name())
+            .phoneNumbers(emptyList())
+            .build();
     assertJson(
         "{\"name\":\"Pensions\",\"appointment_phones\":[]}",
         DatamartDetailedService.class,
@@ -171,6 +194,13 @@ public class DeserializerTest {
         "{\"serviceId\":\"pensions\",\"name\":\"Pensions\",\"appointment_phones\":[]}",
         DatamartDetailedService.class,
         detailedService);
+    detailedService =
+        DatamartDetailedService.builder()
+            .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+            .name(BenefitsService.Pensions.name())
+            .phoneNumbers(emptyList())
+            .serviceLocations(emptyList())
+            .build();
     assertJson(
         "{\"name\":\"Pensions\",\"appointment_phones\":[],\"service_locations\":[]}",
         DatamartDetailedService.class,
@@ -190,7 +220,7 @@ public class DeserializerTest {
                     .deserialize(null, mock(DeserializationContext.class)))
         .isInstanceOf(NullPointerException.class)
         .hasMessage(
-            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jsonParser\" is null");
+            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jp\" is null");
   }
 
   @Test
@@ -203,8 +233,6 @@ public class DeserializerTest {
                     DatamartDetailedService.builder()
                         .serviceId(uncapitalize(BenefitsService.Pensions.name()))
                         .name(BenefitsService.Pensions.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -215,6 +243,16 @@ public class DeserializerTest {
         "{\"detailed_services\":[" + "{\"serviceId\":\"pensions\",\"name\":\"Pensions\"}" + "]}",
         FacilityAttributes.class,
         attributes);
+    attributes =
+        FacilityAttributes.builder()
+            .detailedServices(
+                List.of(
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":[" + "{\"name\":\"Pensions\",\"appointment_phones\":[]}" + "]}",
         FacilityAttributes.class,
@@ -225,6 +263,17 @@ public class DeserializerTest {
             + "]}",
         FacilityAttributes.class,
         attributes);
+    attributes =
+        FacilityAttributes.builder()
+            .detailedServices(
+                List.of(
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Pensions\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -303,14 +352,10 @@ public class DeserializerTest {
                     DatamartDetailedService.builder()
                         .serviceId(uncapitalize(BenefitsService.Pensions.name()))
                         .name(BenefitsService.Pensions.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build(),
                     DatamartDetailedService.builder()
                         .serviceId(uncapitalize(HealthService.Smoking.name()))
                         .name(HealthService.Smoking.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -330,6 +375,21 @@ public class DeserializerTest {
             + "]}",
         DatamartCmsOverlay.class,
         overlay);
+    overlay =
+        DatamartCmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .build(),
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Smoking.name()))
+                        .name(HealthService.Smoking.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Pensions\",\"appointment_phones\":[]},"
@@ -347,6 +407,23 @@ public class DeserializerTest {
             + "]}",
         DatamartCmsOverlay.class,
         overlay);
+    overlay =
+        DatamartCmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build(),
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Smoking.name()))
+                        .name(HealthService.Smoking.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Pensions\",\"appointment_phones\":[],\"service_locations\":[]},"
@@ -426,7 +503,7 @@ public class DeserializerTest {
                     .deserialize(null, mock(DeserializationContext.class)))
         .isInstanceOf(NullPointerException.class)
         .hasMessage(
-            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jsonParser\" is null");
+            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jp\" is null");
   }
 
   @Test
@@ -470,7 +547,7 @@ public class DeserializerTest {
                     .deserialize(null, mock(DeserializationContext.class)))
         .isInstanceOf(NullPointerException.class)
         .hasMessage(
-            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jsonParser\" is null");
+            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jp\" is null");
   }
 
   @Test
@@ -520,7 +597,7 @@ public class DeserializerTest {
                     .deserialize(null, mock(DeserializationContext.class)))
         .isInstanceOf(NullPointerException.class)
         .hasMessage(
-            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jsonParser\" is null");
+            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jp\" is null");
   }
 
   @Test
@@ -734,7 +811,6 @@ public class DeserializerTest {
         serviceLocation);
     serviceLocation =
         DetailedServiceLocation.builder()
-            .appointmentPhoneNumbers(emptyList())
             .emailContacts(
                 List.of(
                     DetailedServiceEmailContact.builder()
@@ -797,8 +873,6 @@ public class DeserializerTest {
         serviceLocation);
     serviceLocation =
         DetailedServiceLocation.builder()
-            .appointmentPhoneNumbers(emptyList())
-            .emailContacts(emptyList())
             .facilityServiceHours(
                 DetailedServiceHours.builder()
                     .monday("8:30AM-7:00PM")
@@ -842,11 +916,7 @@ public class DeserializerTest {
         DetailedServiceLocation.class,
         serviceLocation);
     serviceLocation =
-        DetailedServiceLocation.builder()
-            .appointmentPhoneNumbers(emptyList())
-            .emailContacts(emptyList())
-            .additionalHoursInfo("additional hours info")
-            .build();
+        DetailedServiceLocation.builder().additionalHoursInfo("additional hours info").build();
     assertJson(
         "{" + "\"additional_hours_info\":\"additional hours info\"" + "}",
         DetailedServiceLocation.class,
@@ -855,11 +925,7 @@ public class DeserializerTest {
         "{" + "\"additionalHoursInfo\":\"additional hours info\"" + "}",
         DetailedServiceLocation.class,
         serviceLocation);
-    serviceLocation =
-        DetailedServiceLocation.builder()
-            .appointmentPhoneNumbers(emptyList())
-            .emailContacts(emptyList())
-            .build();
+    serviceLocation = DetailedServiceLocation.builder().build();
     assertJson("{}", DetailedServiceLocation.class, serviceLocation);
     assertJson("{}", DetailedServiceLocation.class, serviceLocation);
     // Exceptions
@@ -869,7 +935,7 @@ public class DeserializerTest {
                     .deserialize(null, mock(DeserializationContext.class)))
         .isInstanceOf(NullPointerException.class)
         .hasMessage(
-            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jsonParser\" is null");
+            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jp\" is null");
   }
 
   @Test
@@ -931,14 +997,10 @@ public class DeserializerTest {
                     DatamartDetailedService.builder()
                         .serviceId(uncapitalize(BenefitsService.Pensions.name()))
                         .name(BenefitsService.Pensions.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build(),
                     DatamartDetailedService.builder()
                         .serviceId(uncapitalize(HealthService.Smoking.name()))
                         .name(HealthService.Smoking.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -958,6 +1020,21 @@ public class DeserializerTest {
             + "]}",
         FacilityAttributes.class,
         attributes);
+    attributes =
+        FacilityAttributes.builder()
+            .detailedServices(
+                List.of(
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .build(),
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Smoking.name()))
+                        .name(HealthService.Smoking.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Pensions\",\"appointment_phones\":[]},"
@@ -975,6 +1052,23 @@ public class DeserializerTest {
             + "]}",
         FacilityAttributes.class,
         attributes);
+    attributes =
+        FacilityAttributes.builder()
+            .detailedServices(
+                List.of(
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(BenefitsService.Pensions.name()))
+                        .name(BenefitsService.Pensions.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build(),
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Smoking.name()))
+                        .name(HealthService.Smoking.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Pensions\",\"appointment_phones\":[],\"service_locations\":[]},"
@@ -1013,8 +1107,6 @@ public class DeserializerTest {
                     DatamartDetailedService.builder()
                         .serviceId(uncapitalize(HealthService.Dental.name()))
                         .name(HealthService.Dental.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -1025,6 +1117,16 @@ public class DeserializerTest {
         "{\"detailed_services\":[" + "{\"serviceId\":\"dental\",\"name\":\"Dental\"}" + "]}",
         DatamartCmsOverlay.class,
         overlay);
+    overlay =
+        DatamartCmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Dental.name()))
+                        .name(HealthService.Dental.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":[" + "{\"name\":\"Dental\",\"appointment_phones\":[]}" + "]}",
         DatamartCmsOverlay.class,
@@ -1035,6 +1137,17 @@ public class DeserializerTest {
             + "]}",
         DatamartCmsOverlay.class,
         overlay);
+    overlay =
+        DatamartCmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Dental.name()))
+                        .name(HealthService.Dental.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Dental\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -1062,14 +1175,18 @@ public class DeserializerTest {
         DatamartDetailedService.builder()
             .serviceId(uncapitalize(HealthService.Dental.name()))
             .name(HealthService.Dental.name())
-            .phoneNumbers(emptyList())
-            .serviceLocations(emptyList())
             .build();
     assertJson("{\"name\":\"Dental\"}", DatamartDetailedService.class, detailedService);
     assertJson(
         "{\"serviceId\":\"dental\",\"name\":\"Dental\"}",
         DatamartDetailedService.class,
         detailedService);
+    detailedService =
+        DatamartDetailedService.builder()
+            .serviceId(uncapitalize(HealthService.Dental.name()))
+            .name(HealthService.Dental.name())
+            .phoneNumbers(emptyList())
+            .build();
     assertJson(
         "{\"name\":\"Dental\",\"appointment_phones\":[]}",
         DatamartDetailedService.class,
@@ -1078,6 +1195,13 @@ public class DeserializerTest {
         "{\"serviceId\":\"dental\",\"name\":\"Dental\",\"appointment_phones\":[]}",
         DatamartDetailedService.class,
         detailedService);
+    detailedService =
+        DatamartDetailedService.builder()
+            .serviceId(uncapitalize(HealthService.Dental.name()))
+            .name(HealthService.Dental.name())
+            .phoneNumbers(emptyList())
+            .serviceLocations(emptyList())
+            .build();
     assertJson(
         "{\"name\":\"Dental\",\"appointment_phones\":[],\"service_locations\":[]}",
         DatamartDetailedService.class,
@@ -1102,8 +1226,6 @@ public class DeserializerTest {
                     DatamartDetailedService.builder()
                         .serviceId(uncapitalize(HealthService.Dental.name()))
                         .name(HealthService.Dental.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -1114,6 +1236,16 @@ public class DeserializerTest {
         "{\"detailed_services\":[" + "{\"serviceId\":\"dental\",\"name\":\"Dental\"}" + "]}",
         FacilityAttributes.class,
         attributes);
+    attributes =
+        FacilityAttributes.builder()
+            .detailedServices(
+                List.of(
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Dental.name()))
+                        .name(HealthService.Dental.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":[" + "{\"name\":\"Dental\",\"appointment_phones\":[]}" + "]}",
         FacilityAttributes.class,
@@ -1124,6 +1256,17 @@ public class DeserializerTest {
             + "]}",
         FacilityAttributes.class,
         attributes);
+    attributes =
+        FacilityAttributes.builder()
+            .detailedServices(
+                List.of(
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(HealthService.Dental.name()))
+                        .name(HealthService.Dental.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"Dental\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -1188,19 +1331,14 @@ public class DeserializerTest {
                     .deserialize(null, mock(DeserializationContext.class)))
         .isInstanceOf(NullPointerException.class)
         .hasMessage(
-            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jsonParser\" is null");
+            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jp\" is null");
   }
 
   @Test
   @SneakyThrows
   void deserializeInvalidDetailedService() {
     DatamartDetailedService invalidService =
-        DatamartDetailedService.builder()
-            .serviceId(INVALID_SVC_ID)
-            .name("foo")
-            .phoneNumbers(emptyList())
-            .serviceLocations(emptyList())
-            .build();
+        DatamartDetailedService.builder().serviceId(INVALID_SVC_ID).name("foo").build();
     assertJson("{\"name\":\"foo\"}", DatamartDetailedService.class, invalidService);
     invalidService.name("OnlineScheduling");
     assertJson(
@@ -1249,7 +1387,7 @@ public class DeserializerTest {
                     .deserialize(null, mock(DeserializationContext.class)))
         .isInstanceOf(NullPointerException.class)
         .hasMessage(
-            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jsonParser\" is null");
+            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jp\" is null");
   }
 
   @Test
@@ -1262,8 +1400,6 @@ public class DeserializerTest {
                     DatamartDetailedService.builder()
                         .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
                         .name(OtherService.OnlineScheduling.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -1276,6 +1412,16 @@ public class DeserializerTest {
             + "]}",
         DatamartCmsOverlay.class,
         overlay);
+    overlay =
+        DatamartCmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+                        .name(OtherService.OnlineScheduling.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"OnlineScheduling\",\"appointment_phones\":[]}"
@@ -1288,6 +1434,17 @@ public class DeserializerTest {
             + "]}",
         DatamartCmsOverlay.class,
         overlay);
+    overlay =
+        DatamartCmsOverlay.builder()
+            .detailedServices(
+                List.of(
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+                        .name(OtherService.OnlineScheduling.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"OnlineScheduling\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -1315,14 +1472,18 @@ public class DeserializerTest {
         DatamartDetailedService.builder()
             .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
             .name(OtherService.OnlineScheduling.name())
-            .phoneNumbers(emptyList())
-            .serviceLocations(emptyList())
             .build();
     assertJson("{\"name\":\"OnlineScheduling\"}", DatamartDetailedService.class, detailedService);
     assertJson(
         "{\"serviceId\":\"onlineScheduling\",\"name\":\"OnlineScheduling\"}",
         DatamartDetailedService.class,
         detailedService);
+    detailedService =
+        DatamartDetailedService.builder()
+            .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+            .name(OtherService.OnlineScheduling.name())
+            .phoneNumbers(emptyList())
+            .build();
     assertJson(
         "{\"name\":\"OnlineScheduling\",\"appointment_phones\":[]}",
         DatamartDetailedService.class,
@@ -1331,6 +1492,13 @@ public class DeserializerTest {
         "{\"serviceId\":\"onlineScheduling\",\"name\":\"OnlineScheduling\",\"appointment_phones\":[]}",
         DatamartDetailedService.class,
         detailedService);
+    detailedService =
+        DatamartDetailedService.builder()
+            .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+            .name(OtherService.OnlineScheduling.name())
+            .phoneNumbers(emptyList())
+            .serviceLocations(emptyList())
+            .build();
     assertJson(
         "{\"name\":\"OnlineScheduling\",\"appointment_phones\":[],\"service_locations\":[]}",
         DatamartDetailedService.class,
@@ -1355,8 +1523,6 @@ public class DeserializerTest {
                     DatamartDetailedService.builder()
                         .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
                         .name(OtherService.OnlineScheduling.name())
-                        .phoneNumbers(emptyList())
-                        .serviceLocations(emptyList())
                         .build()))
             .build();
     assertJson(
@@ -1369,6 +1535,16 @@ public class DeserializerTest {
             + "]}",
         FacilityAttributes.class,
         attributes);
+    attributes =
+        FacilityAttributes.builder()
+            .detailedServices(
+                List.of(
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+                        .name(OtherService.OnlineScheduling.name())
+                        .phoneNumbers(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"OnlineScheduling\",\"appointment_phones\":[]}"
@@ -1381,6 +1557,17 @@ public class DeserializerTest {
             + "]}",
         FacilityAttributes.class,
         attributes);
+    attributes =
+        FacilityAttributes.builder()
+            .detailedServices(
+                List.of(
+                    DatamartDetailedService.builder()
+                        .serviceId(uncapitalize(OtherService.OnlineScheduling.name()))
+                        .name(OtherService.OnlineScheduling.name())
+                        .phoneNumbers(emptyList())
+                        .serviceLocations(emptyList())
+                        .build()))
+            .build();
     assertJson(
         "{\"detailed_services\":["
             + "{\"name\":\"OnlineScheduling\",\"appointment_phones\":[],\"service_locations\":[]}"
@@ -1437,7 +1624,7 @@ public class DeserializerTest {
                     .deserialize(null, mock(DeserializationContext.class)))
         .isInstanceOf(NullPointerException.class)
         .hasMessage(
-            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jsonParser\" is null");
+            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jp\" is null");
   }
 
   @Test
@@ -1485,7 +1672,7 @@ public class DeserializerTest {
                     .deserialize(null, mock(DeserializationContext.class)))
         .isInstanceOf(NullPointerException.class)
         .hasMessage(
-            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jsonParser\" is null");
+            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jp\" is null");
   }
 
   @Test
@@ -1534,7 +1721,7 @@ public class DeserializerTest {
                     .deserialize(null, mock(DeserializationContext.class)))
         .isInstanceOf(NullPointerException.class)
         .hasMessage(
-            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jsonParser\" is null");
+            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jp\" is null");
   }
 
   @Test
@@ -1587,8 +1774,7 @@ public class DeserializerTest {
             + "}",
         Services.class,
         services);
-    services =
-        Services.builder().benefits(emptyList()).health(emptyList()).other(emptyList()).build();
+    services = Services.builder().build();
     assertJson("{}", Services.class, services);
     // Exceptions
     assertThatThrownBy(
@@ -1597,7 +1783,7 @@ public class DeserializerTest {
                     .deserialize(null, mock(DeserializationContext.class)))
         .isInstanceOf(NullPointerException.class)
         .hasMessage(
-            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jsonParser\" is null");
+            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jp\" is null");
   }
 
   @Test
@@ -1640,7 +1826,7 @@ public class DeserializerTest {
             + "}",
         WaitTimes.class,
         waitTimes);
-    assertJson("{}", WaitTimes.class, WaitTimes.builder().health(emptyList()).build());
+    assertJson("{}", WaitTimes.class, WaitTimes.builder().build());
     // Exceptions
     assertThatThrownBy(
             () ->
@@ -1648,6 +1834,6 @@ public class DeserializerTest {
                     .deserialize(null, mock(DeserializationContext.class)))
         .isInstanceOf(NullPointerException.class)
         .hasMessage(
-            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jsonParser\" is null");
+            "Cannot invoke \"com.fasterxml.jackson.core.JsonParser.getCodec()\" because \"jp\" is null");
   }
 }


### PR DESCRIPTION
Changes made to cleanup custom deserializers and improve overall performance:
1) When deserializing, `JsonNode` `asText()` or `asBoolean()` used rather than direct calls to `ObjectMapper` to convert `JsonNode` to `String` or `Boolean`
2) More comprehesive null check for `JsonNode`s has been added; `isNull` and `isNotNull` convience methods introduced in `BaseDeserializer`
3) Creation of empty lists avoided for list attributes in deserializers when respective attributes are missing from JSON
4) `fromString` `JsonCreator` added to `BenefitsService`. Handles `serviceId`, service `name` cases for `eBenefitsRegistrationAssistance`
5) Corrected attribute checks when deserializing benefits, health, and other list attributes for `DatamartServices`
6) Facility transformer cleanup