### PR TITLE
VACMS-1972: Adds correct clinic url

### DIFF
--- a/facilities/src/main/resources/websites.csv
+++ b/facilities/src/main/resources/websites.csv
@@ -1735,7 +1735,7 @@ vha_671GQ,https://www.va.gov/south-texas-health-care/locations/shavano-park-va-c
 vha_671GR,https://www.va.gov/south-texas-health-care/locations/north-bexar-va-clinic/
 vha_671GS,https://www.va.gov/south-texas-health-care/locations/north-west-san-antonio-va-clinic/
 vha_671GT,https://www.va.gov/south-texas-health-care/locations/walzem-va-clinic/
-vha_671GU,https://www.va.gov/south-texas-health-care/locations/san-antonio-va-clinic/
+vha_671GU,https://www.va.gov/south-texas-health-care/locations/san-antonio-pecan-valley-va-clinic/
 vha_671QB,https://www.va.gov/south-texas-health-care/locations/data-point-va-clinic/
 vha_672,https://www.va.gov/caribbean-health-care/locations/san-juan-va-medical-center/
 vha_672B0,https://www.va.gov/caribbean-health-care/locations/euripides-rubio-department-of-veterans-affairs-outpatient-clinic/


### PR DESCRIPTION
Per https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12972, sets the link as follows
- from vha_671GU
- to https://www.va.gov/south-texas-health-care/locations/san-antonio-pecan-valley-va-clinic/