### PR TITLE
Adds Gainesville VA Clinic

### DIFF
--- a/facilities/src/main/resources/websites.csv
+++ b/facilities/src/main/resources/websites.csv
@@ -1133,6 +1133,7 @@ vha_573QG,https://www.va.gov/north-florida-health-care/locations/jacksonville-so
 vha_573QH,https://www.va.gov/north-florida-health-care/locations/ocala-west-va-clinic/
 vha_573QJ,https://www.va.gov/north-florida-health-care/locations/jacksonville-2-va-clinic/
 vha_573QK,https://www.va.gov/north-florida-health-care/locations/lake-city-va-clinic/
+vha_573QL,https://www.va.gov/north-florida-health-care/locations/gainesville-va-clinic/
 vha_575,https://www.va.gov/western-colorado-health-care/locations/grand-junction-va-medical-center/
 vha_575GA,https://www.va.gov/western-colorado-health-care/locations/montrose-va-clinic/
 vha_575GB,https://www.va.gov/western-colorado-health-care/locations/major-william-edward-adams-department-of-veterans-affairs-clinic/


### PR DESCRIPTION
Creates canonical link from
https://www.va.gov/find-locations/facility/vha_573QL
to
https://www.va.gov/north-florida-health-care/locations/gainesville-va-clinic
per https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12661